### PR TITLE
fix Node warnings if >10 instances of PhantomJS launched

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -182,6 +182,8 @@ var run = function () {
         campaign.on('result-serverAttached', function (event) {
             var args = [event.slaveURL];
             var spawn = childProcesses.spawn;
+            process.stdout.setMaxListeners(256); // so that phantomJSinstances can be > 10
+            process.stderr.setMaxListeners(256);
             for (var i = 0, l = browsers.length; i < l; i++) {
                 var curProcess = spawn(browsers[i], args, {
                     stdio: "pipe"


### PR DESCRIPTION
By default Node allows only 10 listeners and logs warnings if more of them are created.
