### PR TITLE
Bump AT version 1.2.6 -> 1.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     },
     "devDependencies": {
         "jasmine-node": "1.0.26",
-        "ariatemplates": "1.2.6",
+        "ariatemplates": "1.3.4",
         "grunt": "0.3.17",
         "grunt-jasmine-node": "0.0.2",
         "grunt-beautify": "0.1.1"


### PR DESCRIPTION
New version is using Grunt build, the old one uses Packman and there are some build failures for some reason.

Also in new AT, we do not build when `npm install` is called.
