### PR TITLE
Configurable number of PhantomJS instances from the includer's package.j...

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -69,7 +69,7 @@ var run = function () {
         'port': 0,
         'log-level': 3,
         'colors': true,
-        'phantomjs-instances': 0,
+        'phantomjs-instances': process.env.npm_package_config_attesterThreads || 0,
         'phantomjs-path': 'phantomjs',
         'ignore-errors': false,
         'ignore-failures': false


### PR DESCRIPTION
...son

After this commit, one who depends on attester in his "scripts" part of
`package.json`, can additionally put in that file the following:

```
 "config":{"phantomjsInstances":2}
```

to specify the number of PhantomJS instances (instead of passing it via
command line), but as the added benefit, the actual user who npm install'ed
his package, could type:

```
 npm config set somePackage:phantomjsInstances 8
```

to take advantage of his multi-core machine.

This setting is taken into account only if there was no
`--phantomjs-instances` passed from the command line when invoking attester.
