### PR TITLE
Fix reading resources from command line issue

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -139,6 +139,14 @@ var run = function () {
     }
 
     if (argv.config) {
+        var argvResources = argv.config.resources;
+        if(argvResources){ // "array-ify" entries in resources so they can get merged properly
+            for(var key in argvResources){
+                if(!Array.isArray(argvResources[key]))
+                    argvResources[key] = [argvResources[key]];
+            }
+        }
+
         merge(configData, argv.config);
     }
 


### PR DESCRIPTION
Now `--config.resources./<customFolder>` items passed from the command line
are read correctly.
