### PR TITLE
Changed error message color to bold red

### DIFF
--- a/lib/logging/console-logger.js
+++ b/lib/logging/console-logger.js
@@ -16,7 +16,7 @@
 require('colors');
 var Logger = require('./logger.js');
 
-var LEVEL_COLORS = ['red', 'yellow', 'green', null];
+var LEVEL_COLORS = [['red', 'bold'], 'yellow', 'green', null];
 var LEVEL_NAMES = ['error', 'warn', 'info', 'debug'];
 
 var ConsoleLogger = function (output) {
@@ -50,7 +50,13 @@ ConsoleLogger.prototype.onLog = function (evt) {
     var color = LEVEL_COLORS[evt.level - 1];
     var message = evt.message;
     if (color) {
-        message = message[color];
+        if(Array.isArray(color)){
+            for(var i = 0, len = color.length; i < len; i++){
+                message = message[color[i]];
+            }
+        } else {
+            message = message[color];
+        }
     }
     var id = buildId(evt.loggersChain).grey;
     this.output.write(id + message + '\n');


### PR DESCRIPTION
Changed the color to increase readability in Git Bash under Windows.

Close #5.
