### PR TITLE
Environment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,46 @@ browsers:
   # The 'name' property allows to change the display name of the browser in the reports.
 ```
 
+**Environment Variables**
+It is possible to build a special portion of the configuration object from an external file using `--env` option.
+
+````
+attester --env package.json
+````
+
+This puts the content of `package.json` inside the `env` section of attester configuration. It is then possible to reference such values with simple templates.
+
+`<%= prop.subprop %>` Expands to the value of `prop.subprop` in the config. Such templates can only be used inside string values, either in arrays or objects
+
+````json
+{
+  "resources": {
+    "/": "src"
+  },
+  "tests": {
+    "mocha": {
+      "files": {
+        "includes": ["spec/**/*"]
+      }
+    }
+  },
+  "coverage": {
+    "files": {
+      "rootDirectory": "src",
+      "includes": ["**/*.js"]
+    }
+  },
+  "coverage-reports": {
+    "json-file": "/reports/coverage-<%= env.version %>.json"
+  }
+}
+````
+
+The configuration above generates a coverage report file called `coverage-x.y.z.json` where `x.y.z` is the value taken from `package.json` or any other file passed referenced by `--env`.
+
+Template options can be used both in `yaml` and `json` file and the environment file can be of any of the two format.
+
+
 **Usual options:**
 
 `--phantomjs-path <path>` Path to the [PhantomJS](http://phantomjs.org/) executable (default: `phantomjs`).
@@ -127,6 +167,8 @@ Otherwise, you'll get runtime errors.*
 `--browser <path>` Path to any browser executable to execute the tests. Can be repeated multiple times to start multiple
 browsers or multiple instances of the same browser. Each browser is started with one parameter: the URL to open to start tests.
 At the end of the tests, all started processes are killed.
+
+`--env <path>` Path to a `yaml` or `json` file containing environment options. See section above.
 
 `--ignore-errors` When enabled, test errors (not including failures) will not cause this process to return a non-zero value.
 
@@ -147,10 +189,10 @@ run tests manually.
 
 **Advanced options**
 
-`--json-console` When enabled, JSON objects will be sent to stdout to provide information about tests.
+`--json-console` When enabled, JSON objects will be sent to `stdout` to provide information about tests.
 This is used by the [junit bridge](https://github.com/ariatemplates/attester-junit).
 
-`--heartbeats` Delay (in ms) for heartbeats messages sent when --json-console is enabled. Use 0 to disable them.
+`--heartbeats` Delay (in ms) for heartbeats messages sent when `--json-console` is enabled. Use `0` to disable them.
 
 **Configuration file options**
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -31,20 +31,21 @@ var config = require('./config');
 
 var run = function () {
     var opt = optimist.usage('Usage: $0 [options] [config.yml|config.json]').boolean(['flash-policy-server', 'json-console', 'help', 'server-only', 'version', 'colors', 'ignore-errors', 'ignore-failures']).string(['phantomjs-path']).describe({
-        'log-level': 'Level of logging: integer from 0 (no logging) to 4 (debug).',
-        'port': 'Port used for the web server. If set to 0, an available port is automatically selected.',
-        'flash-policy-server': 'Whether to enable the built-in Flash policy server.',
-        'flash-policy-port': 'Port used for the built-in Flash policy server (needs --flash-policy-server). Can be 0 for a random port.',
-        'json-console': 'When enabled, JSON objects will be sent to stdout to provide information about tests.',
-        'heartbeats': 'Delay (in ms) for heartbeats messages sent when --json-console is enabled. Use 0 to disable them.',
-        'server-only': 'Only starts the web server, and configure it for the test campaign but do not start the campaign.',
-        'phantomjs-instances': 'Number of instances of PhantomJS to start.',
-        'phantomjs-path': 'Path to PhantomJS executable.',
         'browser': 'Path to any browser executable to execute the tests. Can be repeated multiple times.',
+        'colors': 'Uses colors (disable with --no-colors).',
+        'env': 'Environment configuration file. This file is available in the configuration object under env.',
+        'flash-policy-port': 'Port used for the built-in Flash policy server (needs --flash-policy-server). Can be 0 for a random port.',
+        'flash-policy-server': 'Whether to enable the built-in Flash policy server.',
+        'heartbeats': 'Delay (in ms) for heartbeats messages sent when --json-console is enabled. Use 0 to disable them.',
+        'help': 'Displays this help message and exits.',
         'ignore-errors': 'When enabled, test errors (not including failures) will not cause this process to return a non-zero value.',
         'ignore-failures': 'When enabled, test failures (anticipated errors) will not cause this process to return a non-zero value.',
-        'help': 'Displays this help message and exits.',
-        'colors': 'Uses colors (disable with --no-colors).',
+        'json-console': 'When enabled, JSON objects will be sent to stdout to provide information about tests.',
+        'log-level': 'Level of logging: integer from 0 (no logging) to 4 (debug).',
+        'phantomjs-instances': 'Number of instances of PhantomJS to start.',
+        'phantomjs-path': 'Path to PhantomJS executable.',
+        'port': 'Port used for the web server. If set to 0, an available port is automatically selected.',
+        'server-only': 'Only starts the web server, and configure it for the test campaign but do not start the campaign.',
         'version': 'Displays the version number and exits.'
     }).alias({
         'j': 'json-console',
@@ -100,7 +101,7 @@ var run = function () {
     var consoleLogger = new ConsoleLogger(process.stdout);
     consoleLogger.attach(logger);
 
-    var configData = config.readConfig(argv._[0], argv.config, logger);
+    var configData = config.readConfig(argv._[0], argv.config, argv.env, logger);
 
     var campaign = new TestCampaign(configData, logger);
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -65,14 +65,19 @@ var getDefaults = function () {
     };
 };
 
+// Match '<%= FOO %>' where FOO is a propString, eg. foo or foo.bar but not
+// a method call like foo() or foo.bar().
+var propStringTmplRe = /<%=\s*([a-z0-9_$]+(?:\.[a-z0-9_$]+)*)\s*%>/gi;
+
 /**
  * Read the configuration file (if any) and generate a configuration object with the proper overrides.
  * @param  {String} configFile Configuration file path
  * @param  {Object} override Override some configuration parameters
+ * @param  {Object} environment Environment configuration file
  * @param  {Object} logger
  * @return {Object} Configuration object
  */
-exports.readConfig = function (configFile, override, logger) {
+exports.readConfig = function (configFile, override, environment, logger) {
     var configData = getDefaults();
     if (configFile) {
         configFile = readConfigFile(configFile, logger);
@@ -80,6 +85,15 @@ exports.readConfig = function (configFile, override, logger) {
             return;
         }
         merge(configData, configFile);
+    }
+    if (environment) {
+        environment = readConfigFile(environment, logger);
+        if (configFile !== false) {
+            if (!configData.env) {
+                configData.env = {};
+            }
+            merge(configData.env, environment);
+        }
     }
 
     if (override) {
@@ -94,5 +108,82 @@ exports.readConfig = function (configFile, override, logger) {
 
         merge(configData, override);
     }
-    return configData;
+    return recurse(configData, function (value) {
+        return replace(value, configData);
+    });
 };
+
+
+/**
+ * Recurse through objects and arrays executing a function for each non object.
+ * The return value replaces the original value
+ * @param {Object} value Object on which to recur
+ * @param {Function} fn Callback function
+ */
+
+function recurse(value, fn) {
+    if (Object.prototype.toString.call(value) === "[object Array]") {
+        return value.map(function (value) {
+            return recurse(value, fn);
+        });
+    } else if (Object.prototype.toString.call(value) === "[object Object]") {
+        var obj = {};
+        Object.keys(value).forEach(function (key) {
+            obj[key] = recurse(value[key], fn);
+        });
+        return obj;
+    } else {
+        return fn(value);
+    }
+}
+
+/**
+ * Get the value of a configuration parameter that might use templates
+ * @param {String} value Configuration value
+ * @return {String} String with replacements
+ */
+
+function replace(value, configData) {
+    if (typeof value != "string") {
+        return value;
+    } else {
+        return value.replace(propStringTmplRe, function (match, path) {
+            var value = get(configData, path);
+            if (!(value instanceof Error)) {
+                return value;
+            } else {
+                return match;
+            }
+        });
+    }
+}
+
+// Keep a map of what I'm currently try to get. Avoids circular references
+var memoGet = {};
+/**
+ * Get the value of a json object at a given path
+ * @param {Object} object Container object
+ * @param {String} path Path, delimited by dots
+ * @return {Object} value
+ */
+
+function get(object, path) {
+    if (memoGet[path]) {
+        return new Error("circular reference for " + path);
+    }
+    var parts = path.split(".");
+    var obj = object;
+
+    while (typeof obj === "object" && obj && parts.length) {
+        var part = parts.shift();
+        if (!(part in obj)) {
+            return new Error("invalid path");
+        }
+        obj = obj[part];
+    }
+    memoGet[path] = true;
+    // The replace can cause a circular reference
+    var value = replace(obj, object);
+    delete memoGet[path];
+    return value;
+}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "scripts": {
         "test": "grunt test"
     },
-    "engines" : {
-        "node" : "~0.8.3"
+    "engines": {
+        "node": "~0.8.3"
     }
 }

--- a/spec/cli/configurations/circular.yml
+++ b/spec/cli/configurations/circular.yml
@@ -1,0 +1,3 @@
+first: '<%= second %>'
+second: '<%= third %>'
+third: '<%= first %>'

--- a/spec/cli/configurations/env.yml
+++ b/spec/cli/configurations/env.yml
@@ -1,0 +1,2 @@
+version: '1.2.3'
+name: 'attester'

--- a/spec/cli/configurations/nested.yml
+++ b/spec/cli/configurations/nested.yml
@@ -1,0 +1,6 @@
+one: 'a<%= two %>'
+two: 'b<%= three %>'
+three: 'c<%= another %>'
+four: 'd'
+another: '<%= four %>e'
+full: '<%= one %>'

--- a/spec/cli/configurations/template.json
+++ b/spec/cli/configurations/template.json
@@ -1,0 +1,20 @@
+{
+	"resources": {
+		"/": ["<%=rootPath%>", "<%=paths.root.path%>"]
+	},
+	"tests": {
+		"aria-templates": {
+			"bootstrap": "/aria/aria-templates-<%= env.version %>.js",
+			"classpaths": {
+				"includes": ["MainTestSuite"]
+			}
+		}
+	},
+	"rootPath": "here",
+	"paths": {
+		"root": {
+			"path": "there"
+		},
+		"notReplacing": "<%= missing %>"
+	}
+}

--- a/spec/cli/configurations/template.yml
+++ b/spec/cli/configurations/template.yml
@@ -1,0 +1,16 @@
+resources:
+ '/':
+  - '<%= rootPath %>'
+  - '<%= paths.root.path %>'
+tests:
+ aria-templates:
+  bootstrap: '/aria/aria-templates-<%= env.version %>.js'
+  classpaths:
+   includes:
+    - MainTestSuite
+  rootFolderPath : '/'
+rootPath: 'here'
+paths:
+ root:
+  path: 'there'
+ notReplacing: '<%= missing %>'


### PR DESCRIPTION
Allow to extend the basic configuration with environment parameters taken from a file through the `--env` parameter.

This parameters can then be referenced inside the configuration with a simple templating mechanism.
