### PR TITLE
feat #30 Autooptimize & constrain no. of PhantomJS instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ pass `--phantomjs-path` argument, or add the folder containing `phantomjs.exe` t
 Otherwise, you'll get runtime errors.*
 
 `--phantomjs-instances <number>` Number of instances of [PhantomJS](http://phantomjs.org/) to start (default: `0`).
+Additionally, a string `auto` can be passed to let the program use the optimal number of instances for best performance (max. 1 per CPU thread).
 
 `--browser <path>` Path to any browser executable to execute the tests. Can be repeated multiple times to start multiple
 browsers or multiple instances of the same browser. Each browser is started with one parameter: the URL to open to start tests.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -29,6 +29,7 @@ var writeReports = require('./reports/write-reports.js');
 var childProcesses = require('./child-processes.js');
 var exitProcess = require('./exit-process.js');
 var config = require('./config.js');
+var optimizeParallel = require('./optimize-parallel.js');
 
 var run = function () {
     var opt = optimist.usage('Usage: $0 [options] [config.yml|config.json]').boolean(['flash-policy-server', 'json-console', 'help', 'server-only', 'version', 'colors', 'ignore-errors', 'ignore-failures']).string(['phantomjs-path']).describe({
@@ -124,7 +125,11 @@ var run = function () {
     process.stdout.setMaxListeners(256);
     process.stderr.setMaxListeners(256);
 
-    var phantomJSinstances = argv['phantomjs-instances'];
+    var suggestedInstances = argv['phantomjs-instances'];
+    var phantomJSinstances = optimizeParallel({
+        memoryPerInstance: 60,
+        maxInstances: suggestedInstances
+    }, logger);
     if (phantomJSinstances > 0) {
         campaign.on('result-serverAttached', function (event) {
             var path = argv['phantomjs-path'];

--- a/lib/optimize-parallel.js
+++ b/lib/optimize-parallel.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var os = require('os');
+
+/**
+ * Calculate the number of PhantomJS instances to be run in parallel, considering max threads and available RAM
+ * constraints. Takes as an input the suggested number of instances. This value is then perhaps lowered if there are not
+ * enough resources. If the suggested value is "auto" or undefined, then calculates the maximum possible number.
+ * @param {Object} cfg {maxInstances: Number|String, memoryPerInstance: Number}
+ * @param {Logger} logger
+ * @return {Number}
+ */
+var optimizeNumberOfParallelInstances = function (cfg, logger) {
+    if (cfg.maxInstances === 0) { // explicitly asking for no PhantomJS
+        logger.logInfo("No PhantomJS instances launched.");
+        return 0;
+    }
+
+    var initialMaxInstances = cfg.maxInstances;
+    if (!initialMaxInstances || initialMaxInstances == "auto") {
+        initialMaxInstances = 0;
+    }
+    initialMaxInstances = parseInt(initialMaxInstances, 10);
+    if (isNaN(initialMaxInstances)) {
+        logger.logWarn("Expected cfg.maxInstances to be either 'auto' or numeric. Defaulting to 'auto'");
+        initialMaxInstances = 0;
+    }
+
+    var maxInstances = initialMaxInstances;
+
+    // limit max instances by available CPUs
+    var cpus = os.cpus().length;
+    if (maxInstances === 0 || maxInstances > cpus) {
+        maxInstances = cpus;
+    }
+
+    // further limit max instances by available RAM
+    var availableRamMB = os.freemem() / 1048576;
+    var memPerInstanceMB = parseInt(cfg.memoryPerInstance, 10) || 1;
+    var maxInstancesWithinRam = availableRamMB / memPerInstanceMB;
+    maxInstances = Math.min(maxInstances, maxInstancesWithinRam);
+
+    if (maxInstances < initialMaxInstances) {
+        logger.logWarn("Limiting the number of PhantomJS instances from " + initialMaxInstances + " to " + maxInstances);
+    } else if (initialMaxInstances === 0) {
+        logger.logInfo("Automatic number of PhantomJS instances: " + maxInstances);
+    } else {
+        logger.logInfo("Number of PhantomJS instances: " + maxInstances);
+    }
+
+    return maxInstances;
+};
+
+module.exports = optimizeNumberOfParallelInstances;


### PR DESCRIPTION
Add an option to automatically calculate the best number of PhantomJS instances (if `--phantomjs-instances auto` is passed to the script), and to fix incorrect / too big input values.

The CLI parameter is required, because the default is 0 (don't use Phantom).

The number of instances will be constrained to available CPU threads and free memory. Exceeding the resourced results mostly in decreased performance and/or crashes.

Before that, there was a way to set the number of instances by invoking e.g.

`npm config set ariatemplates:phantomjsInstances 8`

but this worked only when running attester via `npm run-script` (the default value in `package.json` had to be 2 due to limitation of Travis CI).
