### PR TITLE
fix #26 exception in AT test constructor stopping attester 

### DIFF
--- a/lib/test-type/aria-templates/client/run.js
+++ b/lib/test-type/aria-templates/client/run.js
@@ -268,7 +268,11 @@
     }
 
     function startTest() {
-        mainTestObject = Aria.getClassInstance(testClasspath);
+        try {
+            mainTestObject = Aria.getClassInstance(testClasspath);
+        } catch (e) {
+            fatalError("An exception was thrown while trying to instantiate " + testClasspath + ": " + e);
+        }
         registerTest(mainTestObject);
         mainTestObject.run();
     }


### PR DESCRIPTION
When an exception was thrown from the constructor of the AT's test-under-execution, it was not caught by Attester and made it wait indefinitely for the test result.
