### PR TITLE
feat #32 default port 7777; check if port available

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -15,6 +15,7 @@
 
 var optimist = require('optimist');
 var colors = require('colors');
+var portfinder = require('portfinder');
 
 var TestCampaign = require('./test-campaign/campaign.js');
 var TestServer = require('./test-server/server.js');
@@ -61,7 +62,7 @@ var run = function () {
         'log-level': 3,
         'phantomjs-instances': process.env.npm_package_config_phantomjsInstances || 0,
         'phantomjs-path': 'phantomjs',
-        'port': 0
+        'port': 7777
     });
     var argv = opt.argv;
     var reports = [];
@@ -206,8 +207,20 @@ var run = function () {
             testServer.logger.logError('Web server error: %s', [error]);
             endProcess();
         });
-        testServer.server.listen(argv.port, function () {
-            testServer.addCampaign(campaign);
+
+        portfinder.basePort = argv.port;
+        portfinder.getPort(function (err, port) {
+            if (err) {
+                logger.logError("Can't start the server: " + err);
+                return;
+            }
+            if (port != argv.port && argv.port > 0) {
+                // logging error instead of a warning so it's more visible in the console
+                logger.logError("Port %d unavailable; using %d instead.", [argv.port, port]);
+            }
+            testServer.server.listen(port, function () {
+                testServer.addCampaign(campaign);
+            });
         });
     });
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "minimatch": "0.2.11",
         "node-coverage": "1.0.2",
         "optimist": "0.3.5",
+        "portfinder": "0.2.1",
         "send": "0.1.0",
         "socket.io": "0.9.14",
         "ua-parser": "0.3.2"


### PR DESCRIPTION
Attester used to let Node decide about the port for the server if it was not passed as a parameter. This however is not very handy to have random port on each run.

This commits makes 7777 be the default port (unless some value is explicitly passed, or 0 for the old, random behavior).

Also, if the passed port number (or default one) is taken, the next available port number is used instead and a warning is printed.
