### PR TITLE
Interactive page to debug tests

### DIFF
--- a/lib/middlewares/index.js
+++ b/lib/middlewares/index.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Redirect to the index page
+ */
+module.exports = function (req, res, next) {
+    if (req.url === "/" || req.url === "/__attester__" || req.url === "/__attester__/") {
+        // root of the server, redirect to welcome page:
+        res.statusCode = 301;
+        res.setHeader("Location", "/__attester__/index.html");
+        res.end();
+        return;
+    }
+    next();
+};

--- a/lib/middlewares/noCache.js
+++ b/lib/middlewares/noCache.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Disable cache for every request
+ */
+module.exports = function (req, res, next) {
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Pragma', 'no-cache');
+    res.setHeader('Expires', (new Date(0)).toString());
+    next();
+};

--- a/lib/middlewares/template.js
+++ b/lib/middlewares/template.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var _ = require("lodash");
+var fs = require("fs");
+var url = require("url");
+var querystring = require("querystring");
+
+/**
+ * Serve a page with lodash template. This method must be bound to a scope object containing
+ * - data: the data passed to the template
+ * - page: the requested page, starting with forward slash
+ * - path: the path for the requested page as stored on disk
+ *
+ * The template data will contain
+ * - data: the data bound to this template
+ * - url: the parsed url of this request
+ * - query: the parsed query string
+ */
+module.exports = function (req, res, next) {
+    var model = this.data;
+    var page = this.page;
+    var path = this.path;
+    var parsedUrl = url.parse(req.url);
+    var query = querystring.parse(parsedUrl.query);
+
+    if (parsedUrl.pathname != page) {
+        return next();
+    }
+
+    fs.readFile(path, "utf-8", function (err, data) {
+        if (err) {
+            return next(err);
+        }
+
+        var pageContent = _.template(data.toString(), {
+            data: model,
+            url: parsedUrl,
+            query: query
+        });
+
+        res.setHeader("Content-Type", "text/html;charset=utf-8");
+        res.write(pageContent);
+        res.end();
+    });
+};

--- a/lib/test-server/client/index.html
+++ b/lib/test-server/client/index.html
@@ -31,21 +31,15 @@
 			</nav>
 		</hgroup>
 	</header>
-	<div id="main" role="main">
+	<div id="main" role="main" class="">
 		<div id="links" class="column-grid">
-			<div class="column column-span column-first status">
+			<div class="column column-first status">
 				<a href="status.html">
 					<i class="icon-lightbulb"></i>
 				</a>
 				<span>Current Status</span>
 			</div>
-			<div class="column column-span ariatester">
-				<a href="aria-templates/interactive.html">
-					<i class="icon-fire"></i>
-				</a>
-				<span>Aria Tester</span>
-			</div>
-			<div class="column column-span column-last coverage">
+			<div class="column column-last coverage">
 				<a href="coverage/display">
 					<i class="icon-bar-chart"></i>
 				</a>
@@ -54,10 +48,19 @@
 		</div>
 
 		<div id="configuration">
-			<% _.forEach(campaigns, function (campaign) { %>
+			<% _.forEach(data.campaigns, function (campaign) { %>
 			<article>
 				<h2><span>Campaign <%= campaign.id %></span></h2>
 				<div class="text">
+					<% if (campaign.tests.debugUrls.length > 0) { %>
+						<h3>Debug this campaign</h3>
+						<% _.forEach(campaign.tests.debugUrls, function (debug) { %>
+							<a href="<%= debug.url %>"><%= debug.name %></a><br/>
+						<% }); %>
+					<% } %>
+
+
+
 					<h3>Resources</h3>
 					Serving the following resources
 					<ul>

--- a/lib/test-server/client/status.html
+++ b/lib/test-server/client/status.html
@@ -38,7 +38,7 @@
                 <h2><span>Connected Browsers</span></h2>
 
                 <div class="text">
-                    <% if (slaves.length > 0) { %>
+                    <% if (data.slaves.length > 0) { %>
                         <table class="slaves">
                             <thead>
                                 <tr>
@@ -50,12 +50,12 @@
                             </thead>
 
                             <tbody>
-                                <% _.forEach(slaves, function (slave) { %>
+                                <% _.forEach(data.slaves, function (slave) { %>
                                     <tr>
-                                        <td class="browser"><%= slave.displayName %></td>
-                                        <td class="userAgent" data-text="<%= slave.userAgent %>"><%= slave.userAgent %></td>
-                                        <td class="address"><% print((slave.addressName || slave.address) + ':' + slave.port) %></td>
-                                        <td class="status"><% print(slave.getStatus()) %></td>
+                                        <td class="browser" data-is="Browser"><%= slave.displayName %></td>
+                                        <td class="userAgent ellipsis" data-is="User agent" data-text="<%= slave.userAgent %>"><%= slave.userAgent %></td>
+                                        <td class="address ellipsis" data-is="Address" data-text="<% print((slave.addressName || slave.address) + ':' + slave.port) %>"><% print((slave.addressName || slave.address) + ':' + slave.port) %></td>
+                                        <td class="status" data-is="Status"><% print(slave.getStatus()) %></td>
                                     </tr>
                                 <% }); %>
                             </tbody>
@@ -66,7 +66,7 @@
                 </div>
             </article>
 
-            <% _.forEach(campaigns, function (campaign) { %>
+            <% _.forEach(data.campaigns, function (campaign) { %>
             <article>
                 <h2><span>Campaign <%= campaign.id %></span></h2>
                 <div class="text">

--- a/lib/test-server/client/stylesheet.css
+++ b/lib/test-server/client/stylesheet.css
@@ -40,6 +40,7 @@ body {
     font-style: normal;
     color: #333;
     background-color: #f3f3f3;
+    margin: 0;
 }
 
 article, aside, details, figcaption, figure, footer, header, hgroup, nav, section, summary {
@@ -149,32 +150,21 @@ a:hover {
 }
 
 #links {
-    margin-bottom: 280px;
+    margin-bottom: 2em;
+    margin-top: 1em;
 }
 
 .column-grid {
     clear: both;
-}
-
-.column-grid .column-span {
-    width: 25%;
-}
-
-.column-grid .column-first {
-    margin-left: 0;
-}
-
-.column-grid .column-last {
-    margin-right: 0;
-    margin-left: 0;
+    text-align: center;
 }
 
 .column-grid .column {
-    float: left;
-    margin-right: 5%;
-    margin-left: 0;
-    margin-bottom: 18px;
+    display: inline-block;
+    text-align: left;
+    width: 30%;
 }
+
 
 #links a {
     display: block;
@@ -190,17 +180,27 @@ a:hover {
     border-radius: 200px;
     width: 160px;
     height: 160px;
-    -webkit-transition: all 1s ease;
-    -moz-transition: all 1s ease;
-    -o-transition: all 1s ease;
-    transition: all 1s ease;
-    border: 1px solid #fff;
+    -webkit-transition: all 0.2s ease, box-shadow 0.2s;
+    -moz-transition: all 0.2s ease, box-shadow 0.2s;
+    -o-transition: all 0.2s ease, box-shadow 0.2s;
+    transition: all 0.2s ease, box-shadow 0.2s;
+    border: 1px solid #a7a9ac;
 }
 
-#links .ariatester a {
+#links a:hover {
+    box-shadow: 0 0 0 10px rgba(243,243,243,0.4);
+}
+#links a:hover:after {
+    -webkit-transform: scale(0.85);
+    -moz-transform: scale(0.85);
+    -ms-transform: scale(0.85);
+    transform: scale(0.85);
+}
+
+#links .debug a {
     color: #be4b3c;
 }
-#links .ariatester a:hover {
+#links .debug a:hover {
     color: #8C3125;
 }
 
@@ -275,6 +275,7 @@ a:hover {
     -moz-box-shadow: 0px 1px 2px 0px rgba(0,0,0,0.25);
     box-shadow: 0px 1px 2px 0px rgba(0,0,0,0.25);
     border-top: 1px solid #dfdfdf;
+    position: relative;
 }
 
 #configuration .text {
@@ -287,6 +288,22 @@ a:hover {
     line-height: 1.2;
     padding: 5px 0;
     font-weight: bold;
+    margin-top: 1em;
+}
+
+#configuration .text h3:before {
+    content: "\f105";
+    position: absolute;
+    left: 4px;
+    font-family: FontAwesome;
+    font-weight: normal;
+    font-style: normal;
+    text-decoration: inherit;
+    -webkit-font-smoothing: antialiased;
+}
+
+#configuration .text h3:first-of-type {
+    margin-top: 0;
 }
 
 code {
@@ -373,12 +390,17 @@ code {
 }
 .slaves .userAgent {
     width: 300px;
+}
+.slaves .address {
+    width: 300px;
+}
+.ellipsis {
     max-width: 300px;
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
 }
-.slaves td.userAgent:hover::before {
+.ellipsis:hover::before {
     white-space: nowrap;
     overflow: visible;
     background-color: #fff;
@@ -386,9 +408,67 @@ code {
     position: absolute;
     border: 1px solid #ccc;
 }
-.slaves .address {
-    width: 150px;
-    max-width: 150px;
-}
 .slaves .status {
+}
+
+@media screen and (max-width: 680px) {
+    .column-grid .column {
+        width: 45%;
+    }
+    #site-title, h1#site-title, #menu-primary {
+        top : 0;
+    }
+    #main {
+        width: 100%;
+        padding: 0;
+    }
+    table, thead, tbody, th, td, tr {
+        display: block;
+    }
+    thead tr {
+        position: absolute;
+        top: -9999px;
+        left: -9999px;
+    }
+    td {
+        border: none;
+        border-bottom: 1px solid #eee;
+        position: relative;
+        text-align: left;
+        width: 100%;
+        padding-left: 35%;
+    }
+    td:before {
+        position: absolute;
+        left: 6px;
+        width: 45%;
+        padding-right: 10px;
+        white-space: nowrap;
+        content: attr(data-is);
+    }
+    tr {
+        border: 1px solid #ccc;
+    }
+    .ellipsis {
+        max-width: 680px;
+        text-overflow: visible;
+        white-space: wrap;
+    }
+    .ellipsis:hover::before {
+        white-space: nowrap;
+        overflow: visible;
+        background-color: transparent;
+        content : attr(data-is);
+        border: 0;
+    }
+    .slaves .browser, .slaves .userAgent, .slaves .address {
+        width: auto;
+        max-width: 680px;
+    }
+}
+
+@media screen and (max-width: 480px) {
+    .column-grid .column {
+        width: 100%;
+    }
 }

--- a/lib/test-server/server.js
+++ b/lib/test-server/server.js
@@ -26,6 +26,11 @@ var Slave = require('./slave.js');
 var Logger = require('../logging/logger.js');
 var SocketIOLogger = require('../logging/socketio-logger.js');
 
+// middlewares
+var noCache = require("../middlewares/noCache");
+var index = require("../middlewares/index");
+var template = require("../middlewares/template");
+
 var arrayRemove = function (array, item) {
     var index = array.indexOf(item);
     if (index >= 0) {
@@ -35,13 +40,6 @@ var arrayRemove = function (array, item) {
     return false;
 };
 
-var noCache = function (req, res, next) {
-    res.setHeader('Cache-Control', 'no-cache');
-    res.setHeader('Pragma', 'no-cache');
-    res.setHeader('Expires', (new Date(0)).toString());
-    next();
-};
-
 var socketConnection = function (socket) {
     var testServer = this;
     socket.once('hello', function (data) {
@@ -49,37 +47,6 @@ var socketConnection = function (socket) {
             var newSlave = new Slave(socket, data);
             testServer.addSlave(newSlave);
         }
-    });
-};
-
-/**
- * Serve a page with lodash template. This method must be bound to a scope object containing
- * - server : the test server
- * - page : the requested page, starting with forward slash
- */
-var templatePage = function (req, res, next) {
-    if (req.path == '/') {
-        // root of the server, redirect to welcome page:
-        res.statusCode = 301;
-        res.setHeader('Location', '/__attester__/index.html');
-        res.end();
-        return;
-    }
-    var testServer = this.server;
-    var page = this.page;
-    if (req.path != page) {
-        return next();
-    }
-    fs.readFile(path.join(__dirname, '/client', page), "utf-8", function (err, data) {
-        if (err) {
-            return next();
-        }
-
-        var pageContent = _.template(data.toString(), testServer);
-
-        res.setHeader('Content-Type', 'text/html;charset=utf-8');
-        res.write(pageContent);
-        res.end();
     });
 };
 
@@ -172,13 +139,17 @@ var TestServer = function (config, logger) {
     var app = connect();
     app.use(noCache);
     app.use(connect.compress());
-    app.use('/__attester__', templatePage.bind({
-        server: this,
-        page: "/index.html"
+    app.use(index);
+    // Template pages (before the static folder)
+    app.use('/__attester__', template.bind({
+        data: this,
+        page: "/index.html",
+        path: path.join(__dirname, "client", "index.html")
     }));
-    app.use('/__attester__', templatePage.bind({
-        server: this,
-        page: "/status.html"
+    app.use('/__attester__', template.bind({
+        data: this,
+        page: "/status.html",
+        path: path.join(__dirname, "client", "status.html")
     }));
     app.use('/__attester__', connect['static'](__dirname + '/client'));
     app.use('/__attester__/coverage/data', routeCoverage.bind(this));

--- a/lib/test-type/all-tests.js
+++ b/lib/test-type/all-tests.js
@@ -46,6 +46,7 @@ var AllTests = function (campaign, config, parentLogger) {
     this.tasks = [];
     this.tasksTrees = [];
     this.initResults = [];
+    this.debugUrls = [];
 };
 
 var buildTask = function (testType, test, browser) {
@@ -143,13 +144,22 @@ AllTests.prototype.init = function (callback) {
     };
     var endFunction = function (testType) {
         var tasksTrees = buildTasksArrays.call(this, testType, testType.testsTrees);
-        // Only add a node for the test type if there several types are defined:
+        if (tasksTrees.length === 0) {
+            this.logger.logWarn("There are no tasks defined for test type '%s'. Please check the configuration", [testType.name]);
+        }
+        // Only add a node for the test type if several types are defined:
         if (this.testTypesCount == 1) {
             this.tasksTrees = tasksTrees;
         } else {
             this.tasksTrees.push({
                 name: testType.name,
                 subTasks: tasksTrees
+            });
+        }
+        if (testType.debug) {
+            this.debugUrls.push({
+                name: testType.name,
+                url: testType.debug
             });
         }
         decrementExpectedCallbacks();

--- a/lib/test-type/aria-templates/at-test-type.js
+++ b/lib/test-type/aria-templates/at-test-type.js
@@ -14,10 +14,7 @@
  */
 
 var util = require('util');
-var fs = require('fs');
 var path = require('path');
-var url = require('url');
-var querystring = require('querystring');
 
 var connect = require('connect');
 
@@ -25,6 +22,7 @@ var BaseTestType = require('../base-test-type.js');
 var TestsEnumerator = require('./at-tests-enumerator.js');
 
 var merge = require('../../merge.js');
+var template = require('../../middlewares/template');
 
 var sendAttesterTestSuite = function (req, res, next) {
     var output = ['Aria.classDefinition({$classpath:"MainTestSuite",$extends:"aria.jsunit.TestSuite",$constructor:function(){this.$TestSuite.constructor.call(this);\n'];
@@ -36,45 +34,6 @@ var sendAttesterTestSuite = function (req, res, next) {
     output.push('}});');
     res.setHeader('Content-Type', 'text/javascript');
     res.write(output.join(''));
-    res.end();
-};
-
-var sendTest = function (req, res, next) {
-    var parsedUrl = url.parse(req.url);
-    var automatic = (parsedUrl.pathname == '/test.html');
-    if (!automatic) {
-        if (parsedUrl.pathname == '/MainTestSuite.js') {
-            return sendAttesterTestSuite.call(this, req, res, next);
-        }
-        if (parsedUrl.pathname != '/interactive.html') {
-            return next();
-        }
-    }
-    var query = querystring.parse(parsedUrl.query);
-    res.setHeader('Content-Type', 'text/html;charset=utf-8');
-    var content = ['<!doctype html>\n<html><head><title>Aria Templates tester</title>'];
-    content.push('<meta http-equiv="X-UA-Compatible" content="IE=edge" />');
-    content.push('<script type="text/javascript">var Aria=', JSON.stringify(this.ariaConfig), ';</script>');
-    content.push('<script type="text/javascript" src="', encodeURI(this.bootstrap), '"></script>');
-    var extraScripts = this.extraScripts;
-    for (var i = 0, l = extraScripts.length; i < l; i++) {
-        content.push('<script type="text/javascript" src="', encodeURI(extraScripts[i]), '"></script>');
-    }
-    if (automatic) {
-        content.push('<script type="text/javascript">var __testClasspath=', JSON.stringify(query.testClasspath || ""), ';</script>');
-        content.push('<script type="text/javascript" src="/__attester__/aria-templates/run.js"></script>');
-    } else {
-        content.push('<style>html{overflow:hidden;} body{margin:0px;background-color:#FAFAFA;font-family: tahoma,arial,helvetica,sans-serif;font-size: 11px;}</style>');
-    }
-    content.push('</head><body>');
-    if (automatic) {
-        content.push('<div id="TESTAREA"></div>');
-    } else {
-        content.push('<div id="root"></div><script type="text/javascript">var width={min:180};var height={min:342};aria.core.DownloadMgr.updateRootMap({"MainTestSuite":"./"});aria.core.DownloadMgr.updateUrlMap({"MainTestSuite":"MainTestSuite.js"});Aria.loadTemplate({rootDim:{width:width,height:height},classpath:"aria.tester.runner.view.main.Main",div:"root",width:width,height:height,moduleCtrl:{classpath:"aria.tester.runner.ModuleController"}});</script>');
-    }
-    content.push('</body></html>');
-    content = content.join('');
-    res.write(content);
     res.end();
 };
 
@@ -121,10 +80,33 @@ var AriaTemplatesTests = function (campaign, inputConfig) {
     }, this.campaign.logger);
 
     var app = connect();
-    app.use('/__attester__/aria-templates', sendTest.bind(this));
+    app.use('/__attester__/aria-templates', template.bind({
+        data: {
+            ariaConfig: JSON.stringify(ariaConfig),
+            config: testConfig
+        },
+        page: "/test.html",
+        path: path.join(__dirname, "templates", "testPage.html")
+    }));
+    app.use('/__attester__/aria-templates', template.bind({
+        data: {
+            ariaConfig: JSON.stringify(ariaConfig),
+            config: testConfig
+        },
+        page: "/interactive.html",
+        path: path.join(__dirname, "templates", "interactive.html")
+    }));
+    app.use('/__attester__/aria-templates', (function (req, res, next) {
+        if ("/MainTestSuite.js" === req.url) {
+            sendAttesterTestSuite.call(this, req, res, next);
+        } else {
+            next();
+        }
+    }).bind(this));
     app.use('/__attester__/aria-templates', connect['static'](path.join(__dirname, 'client')));
 
     this.handleRequest = app.handle.bind(app);
+    this.debug = "/__attester__/aria-templates/interactive.html";
 };
 
 util.inherits(AriaTemplatesTests, BaseTestType);

--- a/lib/test-type/aria-templates/templates/interactive.html
+++ b/lib/test-type/aria-templates/templates/interactive.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Aria Templates tester</title>
+    <meta name="viewport" content="width=device-width">
+    <script type="text/javascript">var Aria=<%= data.ariaConfig %>;</script>
+    <script type="text/javascript" src="<%= encodeURI(data.config.bootstrap) %>"></script>
+    <% _.forEach(data.config.extraScripts, function (script) { %>
+        <script type="text/javascript" src="<%= encodeURI(script) %>"></script>
+    <% }); %>
+    <style>
+        html{overflow:hidden;}
+        body{margin:0px;background-color:#FAFAFA;font-family:tahoma,arial,helvetica,sans-serif;font-size:11px;}
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <script type="text/javascript">
+        (function () {
+            var width={min:180}, height={min:342};
+            aria.core.DownloadMgr.updateRootMap({
+                "MainTestSuite": "./"
+            });
+            aria.core.DownloadMgr.updateUrlMap({
+                "MainTestSuite": "MainTestSuite.js"
+            });
+            Aria.loadTemplate({
+                rootDim: {width:width,height:height},
+                classpath: "aria.tester.runner.view.main.Main",
+                div: "root",
+                width: width,
+                height: height,
+                moduleCtrl: {
+                    classpath: "aria.tester.runner.ModuleController"
+                }
+            });
+        })();
+    </script>
+</body>
+</html>

--- a/lib/test-type/aria-templates/templates/testPage.html
+++ b/lib/test-type/aria-templates/templates/testPage.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Aria Templates tester</title>
+    <meta name="viewport" content="width=device-width">
+    <script type="text/javascript">var Aria=<%= data.ariaConfig %>;</script>
+    <script type="text/javascript" src="<%= encodeURI(data.config.bootstrap) %>"></script>
+    <% _.forEach(data.config.extraScripts, function (script) { %>
+        <script type="text/javascript" src="<%= encodeURI(script) %>"></script>
+    <% }); %>
+    <script type="text/javascript">var __testClasspath="<%= query.testClasspath %>";</script>
+    <script type="text/javascript" src="/__attester__/aria-templates/run.js"></script>
+</head>
+<body>
+    <div id="TESTAREA"></div>
+</body>
+</html>

--- a/lib/test-type/base-test-type.js
+++ b/lib/test-type/base-test-type.js
@@ -61,4 +61,10 @@ BaseTestType.prototype.handleRequest = function (req, res, next) {
     next();
 };
 
+/**
+ * URL of the debug interface where it should be possible to manually run tests.
+ * @type String
+ */
+BaseTestType.prototype.debug = "";
+
 module.exports = BaseTestType;

--- a/lib/test-type/mocha/mocha-test-type.js
+++ b/lib/test-type/mocha/mocha-test-type.js
@@ -16,15 +16,11 @@
 var util = require('util');
 var connect = require('connect');
 var path = require('path');
-var url = require('url');
-var querystring = require('querystring');
 
 var BaseTestType = require('../base-test-type.js');
 var FileSet = require('../../fileset');
 
 var merge = require('../../merge.js');
-
-var config;
 
 /**
  * Send a test page, this is doing something only when serving test.html
@@ -36,36 +32,7 @@ var config;
  * - assertion/  Assertion libraries
  * - tests/      User defined test files
  */
-var sendTest = function (req, res, next) {
-    var parsedUrl = url.parse(req.url);
-    if (parsedUrl.pathname !== '/test.html') {
-        // We're asking for one the resources
-        return next();
-    }
-    // Send the test
-    var query = querystring.parse(parsedUrl.query);
-    res.setHeader('Content-Type', 'text/html;charset=utf-8');
-    var content = ['<!doctype html>\n<html><head><title>Mocha tests</title>'];
-    content.push('<meta http-equiv="X-UA-Compatible" content="IE=edge" />');
-    content.push('<script src="' + config.assertion + '"></script>');
-    content.push('<link rel="stylesheet" href="/__attester__/mocha/lib/mocha.css" />');
-    var extraScripts = this.extraScripts;
-    for (var i = 0, l = extraScripts.length; i < l; i++) {
-        content.push('<script type="text/javascript" src="', encodeURI(extraScripts[i]), '"></script>');
-    }
-    content.push('<script src="/__attester__/mocha/lib/mocha.js"></script>');
-    content.push('<script src="/__attester__/mocha/client/connector.js"></script>');
-    content.push('<script>mocha.setup(' + buildSetupConfig(config) + ');</script>');
-    content.push('</head><body>');
-    content.push('<div id="mocha"></div>');
-    content.push('<div id="TESTAREA"></div>');
-    content.push('<script src="/__attester__/mocha/tests/' + query.name + '"></script>');
-    content.push('<script>mocha.run();</script>');
-    content.push('</body></html>');
-    content = content.join('');
-    res.write(content);
-    res.end();
-};
+var template = require('../../middlewares/template');
 
 /**
  * Generates the configuration object for mocha.setup()
@@ -100,27 +67,45 @@ var MochaTestType = function (campaign, inputConfig) {
         assertion: 'expect'
     };
     merge(testConfig, inputConfig);
-    config = testConfig;
 
-    BaseTestType.call(this, campaign, config);
+    BaseTestType.call(this, campaign, testConfig);
 
     var app = connect();
-    app.use('/__attester__/mocha', sendTest.bind(this));
+    var mochaSetup = buildSetupConfig(testConfig);
+    app.use('/__attester__/mocha', template.bind({
+        data: {
+            config: testConfig,
+            mochaSetup: mochaSetup
+        },
+        page: "/test.html",
+        path: path.join(__dirname, "templates", "testPage.html")
+    }));
     app.use('/__attester__/mocha/lib', connect['static'](path.dirname(require.resolve('mocha'))));
     app.use('/__attester__/mocha/client', connect['static'](path.join(__dirname, 'client')));
     app.use('/__attester__/mocha/tests', connect['static'](path.join(__dirname, path.relative(__dirname, testConfig.files.rootDirectory))));
 
-    var assertion = config.assertion;
+    var assertion = testConfig.assertion;
     if (/^expect([\.\-]?js)?$/.test(assertion)) {
-        config.assertion = '/__attester__/mocha/assertion/expect.js';
+        testConfig.assertion = '/__attester__/mocha/assertion/expect.js';
         app.use('/__attester__/mocha/assertion', connect['static'](path.dirname(require.resolve('expect.js'))));
     } else if (/chai(\.js)?/.test(assertion)) {
-        config.assertion = '/__attester__/mocha/assertion/chai.js';
+        testConfig.assertion = '/__attester__/mocha/assertion/chai.js';
         app.use('/__attester__/mocha/assertion', connect['static'](path.dirname(require.resolve('chai'))));
     }
+    app.use('/__attester__/mocha', template.bind({
+        data: {
+            config: testConfig,
+            mochaSetup: mochaSetup,
+            // The test list is available only after initialization
+            tests: this.testsTrees
+        },
+        page: "/interactive.html",
+        path: path.join(__dirname, "templates", "interactive.html")
+    }));
 
     this.handleRequest = app.handle.bind(app);
-    this.extraScripts = config.extraScripts;
+    this.debug = "/__attester__/mocha/interactive.html";
+    this.extraScripts = testConfig.extraScripts;
 };
 
 util.inherits(MochaTestType, BaseTestType);

--- a/lib/test-type/mocha/templates/interactive.html
+++ b/lib/test-type/mocha/templates/interactive.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Mocha tests</title>
+    <meta name="viewport" content="width=device-width">
+    <script src="<%= data.config.assertion %>"></script>
+    <link rel="stylesheet" href="/__attester__/mocha/lib/mocha.css" />
+    <% _.forEach(data.config.extraScripts, function (script) { %>
+        <script type="text/javascript" src="<%= encodeURI(script) %>"></script>
+    <% }); %>
+    <script src="/__attester__/mocha/lib/mocha.js"></script>
+    <script>mocha.setup(<%= data.mochaSetup %>);</script>
+</head>
+<body>
+    <div id="mocha"></div>
+    <div id="TESTAREA"></div>
+
+    <% _.forEach(data.tests, function (script) { %>
+        <script src="/__attester__/mocha/tests/<%= encodeURI(script.name) %>"></script>
+    <% }); %>
+    <script>mocha.run();</script>
+</body>
+</html>

--- a/lib/test-type/mocha/templates/testPage.html
+++ b/lib/test-type/mocha/templates/testPage.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Mocha tests</title>
+    <meta name="viewport" content="width=device-width">
+    <script src="<%= data.config.assertion %>"></script>
+    <link rel="stylesheet" href="/__attester__/mocha/lib/mocha.css" />
+    <% _.forEach(data.config.extraScripts, function (script) { %>
+        <script type="text/javascript" src="<%= encodeURI(script) %>"></script>
+    <% }); %>
+    <script src="/__attester__/mocha/lib/mocha.js"></script>
+    <script src="/__attester__/mocha/client/connector.js"></script>
+    <script>mocha.setup(<%= data.mochaSetup %>);</script>
+</head>
+<body>
+    <div id="mocha"></div>
+    <div id="TESTAREA"></div>
+
+    <script src="/__attester__/mocha/tests/<%= query.name %>"></script>
+    <script>mocha.run();</script>
+</body>
+</html>


### PR DESCRIPTION
Add an in interactive page that can be used to easily debug tests of any test-type.

`BaseTestType` now has an additional parameter, `debug` that is specified links to this interactive page.

To do so, this commit introduces generic middlewares.
