### PR TITLE
Bring iframe to front

### DIFF
--- a/lib/test-server/client/slave.css
+++ b/lib/test-server/client/slave.css
@@ -18,7 +18,14 @@ html,body,iframe {
 }
 
 iframe {
-	position: absolute;
+	position: fixed;
+	top: 32px;
+	left: 0;
+	bottom: 0;
+	right: 0;
+	overflow: auto;
+	z-index: 1;
+	background-color: transparent;
 }
 
 html,body {


### PR DESCRIPTION
With the new logging interface there's less space for the test itself.
Put the iframe above and over the rest of the page reserving only the space for the top bar.
