### PR TITLE
Logging with --no-colors outputting objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "attester": "bin/attester.js"
     },
     "dependencies": {
-        "colors": "0.6.0-1",
+        "colors": "0.6.1",
         "connect": "2.7.8",
         "js-yaml": "2.1.0",
         "lodash": "1.3.1",


### PR DESCRIPTION
colors.js hasn't been updated in npm for a long time but it's being updated on Github.

The issue here was that when logging from Attester with `--no-colors` passed in command line, it sometimes logged the String object (`console.dir` fashion) instead of a logging a string literal (precisely it was fixed by https://github.com/Marak/colors.js/commit/5ca667df4a9f86f6c202eca5eb1524cd8d2dd331).
