### PR TITLE
Error summary at the end of each test & campaign 

### DIFF
--- a/lib/attester/reports.js
+++ b/lib/attester/reports.js
@@ -68,11 +68,8 @@ exports.writeReports = function (campaign, callback) {
         var stats = campaign.jsonReport.stats;
         var success = (ignoreErrors || stats.errors === 0) && (ignoreFailures || stats.failures === 0);
 
-        var msg = 'Tests run: ' + stats.testCases + ', ';
-        var msgFailures = stats.failures ? ('Failures: ' + stats.failures + ', ').red.bold : 'Failures: 0, '.green;
-        var msgErrors = stats.errors ? ('Errors: ' + stats.errors + ', ').red.bold : 'Errors: 0, '.green;
-        var msgSkipped = stats.tasksIgnored ? ('Skipped: ' + stats.tasksIgnored).yellow.bold : 'Skipped: 0'.green;
-        attester.logger.logInfo(msg + msgFailures + msgErrors + msgSkipped);
+        logSummary(stats);
+        logErrorsSummary(campaign.jsonReport.tasksErrors);
 
         attester.event.emit("reports.stats", stats);
 
@@ -80,6 +77,34 @@ exports.writeReports = function (campaign, callback) {
     });
 };
 
+function logSummary(stats) {
+    var msg = 'Tests run: ' + stats.testCases + ', ';
+    var msgFailures = stats.failures ? ('Failures: ' + stats.failures + ', ').red.bold : 'Failures: 0, '.green;
+    var msgErrors = stats.errors ? ('Errors: ' + stats.errors + ', ').red.bold : 'Errors: 0, '.green;
+    var msgSkipped = stats.tasksIgnored ? ('Skipped: ' + stats.tasksIgnored).yellow.bold : 'Skipped: 0'.green;
+    attester.logger.logInfo(msg + msgFailures + msgErrors + msgSkipped);
+}
+
+function logErrorsSummary(tasksErrors) {
+    var browsersWithErrors = Object.keys(tasksErrors);
+    if (browsersWithErrors.length === 0) {
+        return;
+    }
+
+    attester.logger.logInfo("------------------------");
+    attester.logger.logInfo("Errors and failures summary:".yellow);
+    browsersWithErrors.forEach(function (browserName) {
+        var errors = tasksErrors[browserName];
+        errors.sort(taskComparator);
+
+        attester.logger.logInfo((browserName + " (" + errors.length + "):").yellow);
+        errors.forEach(function (item) {
+            attester.logger.logError(item.taskName + ": " + item.method);
+            attester.logger.logInfo(" " + item.errorMessage.white);
+        });
+    });
+    attester.logger.logInfo("------------------------");
+}
 
 // Create all global reports, generic for attester
 
@@ -100,14 +125,15 @@ function createGlobals() {
         consoleLogger = new ConsoleLogger(process.stdout);
         consoleLogger.attach(attester.logger);
     }
-
-    globalReports.push(new ConsoleReport(attester.logger, config["slow-test-threshold"]));
 }
 
 function createCampaignReports(campaign) {
     var jsonReport = new JsonReport();
     campaign.on("result", jsonReport.addResult.bind(jsonReport));
     campaign.jsonReport = jsonReport;
+
+    var consoleReport = new ConsoleReport(attester.logger, campaign, config["slow-test-threshold"]);
+    campaign.on("result", consoleReport.addResult.bind(consoleReport));
 
     var logReports = campaign.config["test-reports"]["json-log-file"];
     logReports.forEach(function (logReport) {
@@ -124,6 +150,16 @@ function receiveResult(event) {
     globalReports.forEach(function (report) {
         report.addResult(event);
     });
+}
+
+function taskComparator(el1, el2) {
+    if (el1.taskName > el2.taskName) {
+        return 1;
+    } else if (el1.taskName < el2.taskName) {
+        return -1;
+    } else {
+        return 0;
+    }
 }
 
 exports.__reset__ = function () {

--- a/lib/reports/console-report.js
+++ b/lib/reports/console-report.js
@@ -13,14 +13,15 @@
  * limitations under the License.
  */
 
-var ConsoleReport = function (logger, slowTestThreshold) {
+var ConsoleReport = function (logger, campaign, slowTestThreshold) {
     this.logger = logger;
+    this.campaign = campaign;
     this.slowTestThreshold = slowTestThreshold || 0;
 };
 
 var eventTypes = {
     tasksList: function (event) {
-        this.logger.logInfo("Total %d tasks to be executed.", [event.remainingTasks]);
+        this.logger.logInfo("Total %d tasks to be executed.", [this.campaign.remainingTasks]);
     },
     campaignFinished: function (event) {
         this.logger.logInfo("Campaign finished.");
@@ -28,28 +29,40 @@ var eventTypes = {
     taskIgnored: function (event) {
         this.logger.logWarn("Skipping %s", [event.name]);
     },
-    testFinished: function (event) {
-        if (event.method) {
-            return;
-        }
+    taskFinished: function (event) {
+        var taskId = event.taskId;
 
-        if (event.asserts != null) {
+        var task = this.campaign.jsonReport.tasks[taskId];
+        var taskName = task.name;
+
+        var browser = this.campaign.tasks[taskId].browser;
+        var browserName = browser.name || "default browser";
+        var browserRemainingTasks = browser.pendingTasks;
+
+        if (task.nbAsserts != null) {
+            var totalRemainingTasks = this.campaign.remainingTasks;
+            var duration = event.time - task.startTime;
+
             var msg = "[%s s] [%s] [%d left, %d total] %s: %d assert(s)";
-            if (this.slowTestThreshold && event.duration > this.slowTestThreshold) {
+            if (task.nbFailures > 0 || task.nbErrors > 0) {
+                msg = task.nbFailures ? (msg + "; " + task.nbFailures + " failed") : msg;
+                msg = task.nbErrors ? (msg + "; " + task.nbErrors + " error(s)") : msg;
+                msg = msg.yellow.bold; // there'll be enough red from the earlier error itself
+            } else if (this.slowTestThreshold && duration > this.slowTestThreshold) {
                 msg = msg.bold.inverse;
             }
-            var duration = (event.duration / 1000).toFixed(2);
-            this.logger.logInfo(msg, [duration, event.browserName || "default browser", event.browserRemainingTasks - 1, event.remainingTasks - 1, event.name, event.asserts]);
+
+            duration = (duration / 1000).toFixed(2);
+            this.logger.logInfo(msg, [duration, browserName, browserRemainingTasks, totalRemainingTasks, taskName, task.nbAsserts]);
         } else {
-            this.logger.logInfo("%s", [event.name]);
+            this.logger.logInfo("%s", [taskName]);
         }
-    },
-    taskFinished: function (event) {
+
         if (event.restartPlanned) {
-            this.logger.logWarn("%s will be restarted", [event.taskName]);
+            this.logger.logWarn("%s will be restarted", [taskName]);
         }
-        if (event.browserRemainingTasks === 0) {
-            this.logger.logInfo("All tasks finished for browser: ", [event.browserName || "default browser"]);
+        if (browserRemainingTasks === 0) {
+            this.logger.logInfo("All tasks finished for browser: ", [browserName]);
         }
     },
     error: function (event) {

--- a/lib/reports/json-report.js
+++ b/lib/reports/json-report.js
@@ -41,6 +41,11 @@ function JsonReport() {
         tasks: this.treeReport
     };
     this.tasks = {};
+
+    /**
+     * keys are browser names, values: array of tuples [{ taskName, method, errorMessage }, ...]
+     */
+    this.tasksErrors = {};
     this.remainingTasks = 0;
 }
 
@@ -116,6 +121,9 @@ var eventTypes = {
             // TODO: error
             return;
         }
+        task.nbAsserts = 0;
+        task.nbFailures = 0;
+        task.nbErrors = 0;
         task.startTime = event.time;
         task.events = [];
         this.stats.tasksStarted++;
@@ -134,6 +142,8 @@ var eventTypes = {
             // counts the number of tasks restarts:
             this.stats.tasksRestarts++;
             return;
+            // do not reset nbFailures or nbErrors to 0, the restart will do it
+            // the values might be useful for console report
         }
         processTaskEvents.call(this, task, events);
         task.endTime = event.time;
@@ -157,8 +167,31 @@ var eventTypes = {
         this.stats.tasksIgnored++;
     },
     testStarted: queueTaskEvent,
-    testFinished: queueTaskEvent,
-    error: queueTaskEvent
+    testFinished: function testFinished(event) {
+        if (event.asserts) {
+            // increase number of asserts so that console report can read and display it immediately
+            // in case of task restart, the value will be reset to 0 in 'taskStarted'
+            var task = getRunningTask.call(this, event);
+            task.nbAsserts += event.asserts;
+        }
+
+        // enqueue for final processing (only processed when there are no restarts anymore)
+        queueTaskEvent.call(this, event);
+    },
+    error: function error(event) {
+        // mark failure/error on task so that console report can read and display it immediately;
+        // in case of task restart, those values will be reset to 0 in 'taskStarted'
+        var err = event.error;
+        var task = getRunningTask.call(this, event);
+        if (err.failure) {
+            task.nbFailures++;
+        } else {
+            task.nbErrors++;
+        }
+
+        // enqueue for final processing (only processed when there are no restarts anymore)
+        queueTaskEvent.call(this, event);
+    }
 };
 
 var queuedEventTypes = {
@@ -202,11 +235,19 @@ var queuedEventTypes = {
         if (event.testId) {
             parent = runningTests[event.testId] || task;
         }
-        if (!parent.errors) {
-            parent.errors = [];
-        }
+        parent.errors = parent.errors || [];
         var err = event.error;
         parent.errors.push(err);
+
+        var taskAndBrowserName = task.name.split(" on "); // "taskX on browserY"
+        var browserName = taskAndBrowserName[1] || "default browser";
+        this.tasksErrors[browserName] = this.tasksErrors[browserName] || [];
+        this.tasksErrors[browserName].push({
+            taskName: taskAndBrowserName[0],
+            method: event.method || "",
+            errorMessage: err.message
+        });
+
         if (err.failure) {
             this.stats.failures++;
         } else {

--- a/lib/test-campaign/test-campaign.js
+++ b/lib/test-campaign/test-campaign.js
@@ -147,7 +147,6 @@ TestCampaign.prototype.addResult = function (event) {
         this.remainingTasks--;
         this.checkFinished();
     }
-    event.remainingTasks = this.remainingTasks;
     if (this.results) {
         this.results.push(event);
     }

--- a/lib/test-server/slave-server.js
+++ b/lib/test-server/slave-server.js
@@ -89,9 +89,6 @@ var emitTaskError = function (scope, message, restart) {
 
 var feedEventWithTaskData = function (event, task) {
     event.taskId = task.taskId;
-    event.taskName = task.test.name;
-    event.browserName = task.browser.name;
-    event.browserRemainingTasks = task.browser.pendingTasks;
     return event;
 };
 


### PR DESCRIPTION
I'm counting errors and failures on the slave, perhaps this should be done in `json-report` instead? But this seemed a bit strange for me, it would require augmenting the `event` on-the-fly when it arrives to the `json-report` before it is dispatched to `console-report`. I checked and it works but seems hacky to me.

---

Here's the preview of updated logging (the first error is actually an issue with Attester itself after recent refactoring):

![preview](https://f.cloud.github.com/assets/1437027/901133/a2163b50-fb77-11e2-9c58-9be4da2c2e8d.png)
