### PR TITLE
Less strict error logging on PhantomJS exit

### DIFF
--- a/lib/launchers/phantom.js
+++ b/lib/launchers/phantom.js
@@ -37,13 +37,14 @@ attester.event.once("launcher.connect", function (slaveURL) {
         var args = [pathUtil.join(__dirname, '../browsers/phantomjs.js'), "--auto-exit", slaveURL];
         var spawn = childProcesses.spawn;
         // BACKWARD-COMPAT node 0.8 start
-        var checkPhantomjsSpawnExitCode = function (code) {
+        var checkPhantomjsSpawnExitCode = function (code, signal) {
             if (code === 127) {
                 logger.logError("Spawn: exited with code 127. PhantomJS executable not found. Make sure to download PhantomJS and add its folder to your system's PATH, or pass the full path directly to Attester via --phantomjs-path.\nUsed command: '" + path + "'");
             } else if (code === 126) {
                 logger.logError("Spawn: exited with code 126. Unable to execute PhantomJS. Make sure to have proper read & execute permissions set.\nUsed command: '" + path + "'");
-            } else if (code !== 0) {
-                logger.logError("Spawn: PhantomJS exited with code " + code);
+            } else if (code !== 0 && signal !== "SIGTERM") {
+                var diagnostics = (code !== null ? ("code: " + code) : "") + (signal ? "signal: " + signal : "");
+                logger.logError("Spawn: PhantomJS exited with " + diagnostics);
             }
         };
         // BACKWARD-COMPAT node 0.8 end


### PR DESCRIPTION
Do not log error if PhantomJS is closed with SIGTERM.

---

There have been some subtle code changes after 1.2.1 which make PhantomJS sometimes exit with SIGTERM signal received instead of cleanly with code 0, there's no need to log any error in situation like this.
