### PR TITLE
Filter tests to be run by jasmine

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,6 +14,12 @@
  */
 
 module.exports = function (grunt) {
+    // One may filter tests to be run; useful for debugging.
+    // Usage (any regexp should do):
+    //   grunt jasmine_node --grep=load_plugin
+    //   grunt jasmine_node --grep="(event.*|config)"
+    var grep = grunt.option('grep') || "";
+
     grunt.initConfig({
         jshint: {
             all : ['package.json', 'grunt.js', 'lib/**/*.js', 'spec/**/*.spec.js', '!lib/**/html5shiv.js'],
@@ -27,6 +33,7 @@ module.exports = function (grunt) {
             tasks: ['dev']
         },
         jasmine_node: {
+            match : grep + ".", // "." is the default
             forceExit: true
         },
         beautify: {


### PR DESCRIPTION
Possibility to filter which attester specs should run; useful for debugging attester.

Usage:

```
   grunt jasmine_node --grep=<pattern>
```

I went with `grep` instead of `regex` etc. to be consistent with mocha.
