### PR TITLE
Better error msg when test case has syntax error

### DIFF
--- a/lib/test-type/aria-templates/at-environment.js
+++ b/lib/test-type/aria-templates/at-environment.js
@@ -77,9 +77,17 @@ ATEnvironment.prototype.readATClasspath = function (classpath, callback) {
         };
         var handleResult = function (result) {
             if (filePath && result.classpath != classpath) {
+                var msg;
+                if (!result.classpath) {
+                    msg = "File '%s' doesn't contain the class '%s'. Check for the syntax errors in the file.";
+                    result.classpath = "";
+                } else {
+                    msg = "File '%s' should contain classpath '%s' but it contains '%s'.";
+                }
+
                 result = {
                     error: {
-                        message: "File '%s' should contain classpath '%s' but it contains '%s'.",
+                        message: msg,
                         args: [filePath, classpath, result.classpath]
                     }
                 };


### PR DESCRIPTION
If a file has a syntax error then `result.classpath == undefined` and the error message is not very helpful.
