### PR TITLE
Fixing an issue with browser disconnection and task timeouts.

### DIFF
--- a/lib/test-server/slave.js
+++ b/lib/test-server/slave.js
@@ -36,20 +36,31 @@ var wrapInTryCatch = function (scope, fct) {
     };
 };
 
-var campaignTaskFinished = function (scope, campaign, task) {
+var campaignTaskFinished = function (scope) {
+    var task = scope.currentTask;
+    var campaign = scope.currentCampaign;
+    scope.currentTask = null;
+    scope.currentCampaign = null;
+    if (scope.taskTimeoutId != null) {
+        clearTimeout(scope.taskTimeoutId);
+        scope.taskTimeoutId = null;
+    }
     var event = {
         event: "taskFinished"
     };
     task.browser.onTaskFinished();
     feedEventWithTaskData(event, task);
     campaign.addResult(event);
+    if (scope.socket) {
+        scope.socket.emit('slave-stop');
+        scope.emitAvailable();
+    }
 };
 
 var emitTaskError = function (scope, message) {
     var task = scope.currentTask;
     if (task) {
-        var campaign = scope.currentCampaign;
-        campaign.addResult({
+        scope.currentCampaign.addResult({
             event: "error",
             taskId: task.taskId,
             taskName: task.test.name,
@@ -58,9 +69,7 @@ var emitTaskError = function (scope, message) {
             },
             name: task.test.name
         });
-        campaignTaskFinished(scope, campaign, task);
-        scope.currentTask = null;
-        scope.currentCampaign = null;
+        campaignTaskFinished(scope);
     }
 };
 
@@ -155,30 +164,31 @@ Slave.prototype.onPauseChanged = function (paused) {
 };
 
 Slave.prototype.onSocketDisconnected = function () {
-    var task = this.currentTask;
-    emitTaskError(this, "Browser was disconnected: " + this.toString());
-    this.emit('disconnect');
-};
-
-Slave.prototype.onTaskFinished = function () {
-    var task = this.currentTask;
-    var campaign = this.currentCampaign;
-    this.currentTask = null;
-    this.currentCampaign = null;
-    clearTimeout(this.taskTimeoutId);
-    this.socket.emit('slave-stop');
-    campaignTaskFinished(this, campaign, task);
-    if (!this.paused) {
-        this.emit('available');
+    if (this.socket) {
+        this.socket = null;
+        emitTaskError(this, "Browser was disconnected: " + this.toString());
+        this.emit('disconnect');
     }
 };
 
+Slave.prototype.onTaskFinished = function () {
+    campaignTaskFinished(this);
+};
+
 Slave.prototype.disconnect = function () {
-    this.socket.disconnect();
+    if (this.socket) {
+        this.socket.disconnect();
+    }
 };
 
 Slave.prototype.isAvailable = function () {
-    return !(this.paused || this.currentTask);
+    return this.socket && !(this.paused || this.currentTask);
+};
+
+Slave.prototype.emitAvailable = function () {
+    if (this.isAvailable()) {
+        this.emit('available');
+    }
 };
 
 Slave.prototype.getStatus = function () {
@@ -192,11 +202,8 @@ Slave.prototype.getStatus = function () {
 };
 
 Slave.prototype.taskTimeout = function () {
-    this.socket.emit('slave-stop');
+    this.taskTimeoutId = null;
     emitTaskError(this, "Task timeout.");
-    if (!this.paused) {
-        this.emit('available');
-    }
 };
 
 module.exports = Slave;

--- a/spec/cli/timeout.spec.js
+++ b/spec/cli/timeout.spec.js
@@ -1,0 +1,65 @@
+/*globals describe, it, runs, waitsFor, expect*/
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var path = require("path");
+var utils = require("../test-utils");
+
+describe('timeout', function () {
+
+    it("after disconnect", function () {
+        // this test starts attester with a first test which disconnects the browser
+        // then it checks that attester is waiting for a browser to connect
+        // instead of automatically making tasks timeout
+        var attesterFinished = false;
+        var phantomFinished = false;
+        var okToContinue = false;
+        runs(function () {
+            utils.runFromCommandLine({
+                testCase: "timeout after disconnect",
+                timeout: 10000,
+                args: ['--config.tests.mocha.files.includes', 'spec/test-type/mocha/extraScripts/disconnect.js', '--config.tests.mocha.files.includes', 'spec/test-type/mocha/sample-tests/**/*Test.js', '--task-timeout', '500']
+            }, function (code, testExecution, errorMessages) {
+                attesterFinished = true;
+                expect(errorMessages.length).toEqual(1);
+                expect(errorMessages[0]).toContain("Browser was disconnected");
+                expect(testExecution).toEqual({
+                    run: 3,
+                    failures: 0,
+                    errors: 1,
+                    skipped: 0
+                });
+            });
+            setTimeout(function () {
+                okToContinue = true;
+            }, 6000);
+        });
+        waitsFor(function () {
+            return attesterFinished || okToContinue;
+        }, 7000, 'some time');
+        runs(function () {
+            utils.startPhantom([path.join(__dirname, '../../lib/browsers/phantomjs.js'), "--auto-exit", "http://localhost:7777/__attester__/slave.html"], function () {}, function (code) {
+                phantomFinished = true;
+            });
+        });
+        waitsFor(function () {
+            return attesterFinished && phantomFinished;
+        }, 3000, 'attester and phantom to complete');
+        runs(function () {
+            expect(attesterFinished).toEqual(true);
+            expect(phantomFinished).toEqual(true);
+        });
+    });
+});


### PR DESCRIPTION
This pull request fixes the following bug: when a browser is disconnected
during a test, the task timeout function is not canceled. When it is
executed, it assigns a new task to the disconnected browser, which
will lead to a timeout (as there is no browser connected to execute
the task), and then another task will be assigned and so on...
