### PR TITLE
Improve error handling for PhantomJS

### DIFF
--- a/lib/browsers/phantomjs.js
+++ b/lib/browsers/phantomjs.js
@@ -18,9 +18,11 @@ var system = require('system');
 var url;
 var autoExit = false;
 // Id for this instance of PhantomJS
-var id = new Date().getTime() % 100;
+var instanceId = Math.round(Math.random() * 1000) % 1000;
 // When auto-exit is enabled, check for errors every x milliseconds
-var autoexitPolling = 5000;
+var autoexitPolling = 8000;
+// Wait for `DOMContentLoaded` for x milliseconds, then for `load` the same amount
+var pageOpenTimeoutMs;
 
 var parseCommandLine = function () {
     var args = system.args;
@@ -29,6 +31,8 @@ var parseCommandLine = function () {
             autoExit = true;
         } else if (args[i].indexOf("--auto-exit-polling") === 0) {
             autoexitPolling = parseInt(args[i].split("=")[1], 10) || autoexitPolling;
+        } else if (args[i].indexOf("--instance-id") === 0) {
+            instanceId = parseInt(args[i].split("=")[1], 10);
         } else {
             url = args[i];
         }
@@ -36,8 +40,9 @@ var parseCommandLine = function () {
 };
 
 parseCommandLine();
+pageOpenTimeoutMs = autoexitPolling;
 
-var logHeader = "[PhantomJS " + id + "]";
+var logHeader = "[PhantomJS " + instanceId + "]";
 console.log(logHeader + " opening URL " + url);
 
 var page = require('webpage').create();
@@ -75,11 +80,22 @@ page.onInitialized = function (arg1) {
 };
 
 var callbacks = {
-    'attesterOnDisconnect': function () {
+    'DOMContentLoaded': function () {
+        console.debug(logHeader, "DOMContentLoaded");
+        // `DOMContentLoaded` was raised, give server some more time fire `onload`.
+        // Note it's likely the websocket connection has already been established at this point
+        // and a test was assigned to this browser instance
+        clearTimeout(pageOpenTimeout);
+        pageOpenTimeout = makePageOpenTimeout("load");
+    },
+    'attesterOnDisconnect': function (bDumpPageContents) {
         if (autoExit) {
+            bDumpPageContents = (bDumpPageContents !== false);
             console.log(logHeader, "exiting");
-            console.log("Page content of URL", page.url, "\n", page.content);
-            phantom.exit();
+            if (bDumpPageContents) {
+                console.log("Page content of URL", page.url, "\n", page.content);
+            }
+            phantom.exit(75);
         }
     },
     'sendEvent': function (event) {
@@ -121,8 +137,8 @@ page.onError = function (error, stack) {
 };
 
 /**
- * Checks for errors in the opened page every 'autoexitPolling' milliseconds, this value can be controlled
- * by the command line parameter --auto-exit-polling=x
+ * Checks for errors in the opened page every 'autoexitPolling' milliseconds, this value can be controlled by the
+ * command line parameter --auto-exit-polling=x
  */
 
 function startPollingForErrors() {
@@ -149,10 +165,25 @@ function startPollingForErrors() {
     }
 }
 
-var pageOpenTimeout = setTimeout(function () {
-    console.log(logHeader, "no reply from server after", 2 * autoexitPolling, "milliseconds");
-    callbacks["attesterOnDisconnect"]();
-}, 2 * autoexitPolling);
+function makePageOpenTimeout(expectedEvent) {
+    return setTimeout(function () {
+        console.log(logHeader, "Timed out after waiting", pageOpenTimeoutMs, "milliseconds for the", expectedEvent, "event");
+        // this is recoverable error, do not dump page contents
+        callbacks["attesterOnDisconnect"](false);
+    }, pageOpenTimeoutMs);
+}
+
+var pageOpenTimeout = makePageOpenTimeout("DOMContentLoaded");
+
+page.onInitialized = function () {
+    page.evaluate(function () {
+        document.addEventListener("DOMContentLoaded", function () {
+            window.callPhantom({
+                name: "DOMContentLoaded"
+            });
+        }, false);
+    });
+};
 
 page.open(url, function (status) {
     clearTimeout(pageOpenTimeout);
@@ -160,6 +191,7 @@ page.open(url, function (status) {
         console.log(logHeader, "page open error with status:", status);
         callbacks["attesterOnDisconnect"]();
     } else {
+        console.debug(logHeader, "page loaded correctly");
         startPollingForErrors();
     }
 });

--- a/lib/launchers/phantom.js
+++ b/lib/launchers/phantom.js
@@ -14,56 +14,196 @@
  */
 var pathUtil = require("path");
 
+var exitProcess = require("exit");
+
 var optimizeParallel = require("../optimize-parallel.js");
-var childProcesses = require("../child-processes.js");
+var spawn = require("../child-processes.js").spawn;
 
 /**
- * Launcher for PhantomJS, this module listen to attester event to create phantom
- * instances and connect them as slaves
+ * Launcher for PhantomJS, this module listen to attester event to create phantom instances and connect them as slaves
  */
 
 var attester = require("../attester");
 var config = attester.config;
 var logger = attester.logger;
 
-attester.event.once("launcher.connect", function (slaveURL) {
-    var suggestedInstances = config["phantomjs-instances"];
-    var phantomJSinstances = optimizeParallel({
-        memoryPerInstance: 60,
-        maxInstances: suggestedInstances
-    }, logger);
-    if (phantomJSinstances > 0) {
-        var path = config["phantomjs-path"];
-        var args = [pathUtil.join(__dirname, '../browsers/phantomjs.js'), "--auto-exit", slaveURL];
-        var spawn = childProcesses.spawn;
-        // BACKWARD-COMPAT node 0.8 start
-        var checkPhantomjsSpawnExitCode = function (code) {
-            if (code === 127) {
-                logger.logError("Spawn: exited with code 127. PhantomJS executable not found. Make sure to download PhantomJS and add its folder to your system's PATH, or pass the full path directly to Attester via --phantomjs-path.\nUsed command: '" + path + "'");
-            } else if (code === 126) {
-                logger.logError("Spawn: exited with code 126. Unable to execute PhantomJS. Make sure to have proper read & execute permissions set.\nUsed command: '" + path + "'");
-            } else if (code !== 0) {
-                logger.logError("Spawn: PhantomJS exited with code " + code);
+// Most of the entries in cfg will be set later in "launcher.connect" listener
+var cfg = {
+    maxRetries: 3,
+    // how many times to retry rebooting phantom in case of recoverable errors
+    onAllPhantomsDied: function () {
+        endProcess(1);
+    },
+    phantomPath: null,
+    slaveURL: null,
+    pipeStdOut: true,
+    phantomInstances: 0
+};
+var state = {
+    retries: [],
+    // stores how many times each instance was rebooted
+    erroredPhantomInstances: 0
+    // stores how many phantoms died unrecoverably
+};
+
+// Exposing all those methods for the sake of testability.
+// They don't rely on global `cfg` and `state` but on parameters for for the same reason.
+module.exports = {
+    /**
+     * Starts PhantomJS child process with instance number `n` using `cfg.path` as PhantomJS path and connects it to
+     * `cfg.slaveURL`
+     * @param {Object} cfg
+     * @param {Object} state
+     * @param {Integer} n
+     */
+    bootPhantom: function (cfg, state, n) {
+        cfg.args = cfg.args || {};
+        var phantomPath = cfg.phantomPath;
+        var controlScript = pathUtil.join(__dirname, '../browsers/phantomjs.js');
+
+        var args = [];
+        args.push(controlScript);
+        args.push("--auto-exit");
+        if (cfg.args.autoExitPolling) {
+            args.push("--auto-exit-polling=" + cfg.args.autoExitPolling);
+        }
+        if (n) {
+            args.push("--instance-id=" + n);
+        }
+        args.push(cfg.slaveURL);
+
+        var phantomProcess = spawn(phantomPath, args, {
+            stdio: "pipe"
+        });
+        if (cfg.pipeStdOut) {
+            phantomProcess.stdout.pipe(process.stdout);
+            phantomProcess.stderr.pipe(process.stderr);
+        }
+        if (cfg.onData) {
+            phantomProcess.stdout.on("data", cfg.onData);
+        }
+        phantomProcess.on("exit", cfg.onExit || this.createPhantomExitCb(cfg, state, n).bind(this));
+        phantomProcess.on("error", cfg.onError || this.createPhantomErrorCb(cfg, state, n).bind(this));
+        return phantomProcess;
+    },
+
+    /**
+     * Factory of callback functions to be used as 'exit' listener by PhantomJS processes.
+     * @param {Object} cfg
+     * @param {Object} state
+     * @param {Integer} n
+     * @return {Function}
+     */
+    createPhantomExitCb: function (cfg, state, n) {
+        // Node 0.8 and 0.10 differently handle spawning errors ('exit' vs 'error'), but errors that happened after
+        // launching the command are both handled in 'exit' callback
+        return function (code, signal) {
+            // See http://tldp.org/LDP/abs/html/exitcodes.html and http://stackoverflow.com/a/1535733/
+            if (code === 0) {
+                return;
+            }
+
+            var isNotRecoverable = (code == 127 || code == 126);
+            if (isNotRecoverable) {
+                ++state.erroredPhantomInstances;
+                var path = cfg.phantomPath;
+                if (code == 127) {
+                    logger.logError("Spawn: exited with code 127. PhantomJS executable not found. Make sure to download PhantomJS and add its folder to your system's PATH, or pass the full path directly to Attester via --phantomjs-path.\nUsed command: '" + path + "'");
+                } else if (code == 126) {
+                    logger.logError("Spawn: exited with code 126. Unable to execute PhantomJS. Make sure to have proper read & execute permissions set.\nUsed command: '" + path + "'");
+                }
+                checkIfAllPhantomsDied(cfg, state);
+                return;
+            }
+
+            // Now, try to recover unless retried too many times
+
+            // prepare error message
+            var errMsg;
+            if (code == 75) {
+                errMsg = "Spawn: PhantomJS[" + n + "] exited with code 75: unable to load attester page within specified timeout, or errors happened while loading.";
+                if (cfg.phantomInstances > 1) {
+                    errMsg += " You may try decreasing the number of PhantomJS instances in attester config to avoid that problem.";
+                }
+            } else {
+                errMsg = "Spawn: PhantomJS[" + n + "] exited with code " + code + " and signal " + signal;
+            }
+
+            // check how many retries happened for this instance
+            var retries = state.retries;
+            retries[n] = (retries[n] || 0) + 1;
+            if (retries[n] < cfg.maxRetries) {
+                // log just a warning and try rebooting
+                logger.logWarn(errMsg);
+                logger.logWarn("Trying to reboot instance nr " + n + "...");
+                this.bootPhantom(cfg, state, n);
+            } else {
+                logger.logError(errMsg);
+                ++state.erroredPhantomInstances;
+                checkIfAllPhantomsDied(cfg, state);
             }
         };
-        // BACKWARD-COMPAT node 0.8 end
-        var onPhantomJsSpawnError = function (err) {
-            if (err.code === "ENOENT") {
-                logger.logError("Spawn: exited with code ENOENT. PhantomJS executable not found. Make sure to download PhantomJS and add its folder to your system's PATH, or pass the full path directly to Attester via --phantomjs-path.\nUsed command: '" + path + "'");
+    },
+
+    /**
+     * Factory of callback functions to be used as 'error' listener by PhantomJS processes.
+     * @param {Object} cfg
+     * @param {Object} state
+     * @param {Integer} n
+     * @return {Function}
+     */
+    createPhantomErrorCb: function (cfg, state, n) {
+        return function (err) {
+            if (err.code == "ENOENT") {
+                logger.logError("Spawn: exited with code ENOENT. PhantomJS executable not found. Make sure to download PhantomJS and add its folder to your system's PATH, or pass the full path directly to Attester via --phantomjs-path.\nUsed command: '" + cfg.phantomPath + "'");
             } else {
                 logger.logError("Unable to spawn PhantomJS; error code " + err.code);
             }
         };
-        for (var i = 0; i < phantomJSinstances; i++) {
-            var curProcess = spawn(path, args, {
-                stdio: "pipe"
-            });
-            curProcess.stdout.pipe(process.stdout);
-            curProcess.stderr.pipe(process.stderr);
-            // BACKWARD-COMPAT node 0.8 start
-            curProcess.on("exit", checkPhantomjsSpawnExitCode); // node 0.8
-            // BACKWARD-COMPAT node 0.8 end
-            curProcess.on("error", onPhantomJsSpawnError); // node 0.10
+    }
+};
+
+attester.event.once("launcher.connect", function (slaveURL) {
+    var suggestedInstances = config["phantomjs-instances"]; // config is not available earlier
+    var phantomInstances = optimizeParallel({
+        memoryPerInstance: 60,
+        maxInstances: suggestedInstances
+    }, logger);
+    if (phantomInstances === 0) {
+        return;
+    }
+
+    // Set cfg so that functions depending on these globals work fine
+    cfg.phantomInstances = phantomInstances;
+    cfg.phantomPath = config["phantomjs-path"];
+    cfg.slaveURL = slaveURL;
+
+    logger.logDebug("Spawning " + phantomInstances + " instances of PhantomJS");
+    if (phantomInstances == 1) {
+        // If there's only one phantom, let's assign it a random "id"
+        // This is for analyzing logs of attester suite itself
+        // For normal users requesting N phantoms, assign them ids 1 through N
+        module.exports.bootPhantom(cfg, state);
+    } else {
+        for (var n = 1; n <= phantomInstances; n++) {
+            module.exports.bootPhantom(cfg, state, n);
         }
     }
 });
+
+function checkIfAllPhantomsDied(cfg, state) {
+    // If all phantoms died and were unable to recover, something is really wrong
+    if (state.erroredPhantomInstances === cfg.phantomInstances && cfg.phantomInstances > 0) {
+        logger.logError("All the instances of PhantomJS were terminated with errors; disposing attester and exiting");
+        if (cfg.onAllPhantomsDied) {
+            cfg.onAllPhantomsDied();
+        }
+    }
+}
+
+function endProcess(code) {
+    attester.event.emit("closing");
+    process.nextTick(function () {
+        exitProcess(code);
+    });
+}

--- a/spec/cli/timeout.spec.js
+++ b/spec/cli/timeout.spec.js
@@ -50,7 +50,7 @@ describe('timeout', function () {
             return attesterFinished || okToContinue;
         }, 7000, 'some time');
         runs(function () {
-            utils.startPhantom([path.join(__dirname, '../../lib/browsers/phantomjs.js'), "--auto-exit", "http://localhost:7777/__attester__/slave.html"], function () {}, function (code) {
+            utils.startPhantom([path.join(__dirname, '../../lib/browsers/phantomjs.js'), "--auto-exit", "--auto-exit-polling=2000", "http://localhost:7777/__attester__/slave.html"], function () {}, function (code) {
                 phantomFinished = true;
             });
         });

--- a/spec/test-utils.js
+++ b/spec/test-utils.js
@@ -33,6 +33,7 @@ exports.createServer = function (fromType, extraPath, callback) {
     });
 };
 
+// Deprecated, use /attester/lib/launchers/phantom:bootPhantom which is more generic
 exports.startPhantom = function (args, onData, onExit) {
     var phantomProcess = spawn("phantomjs", args, {
         stdio: "pipe"
@@ -47,7 +48,6 @@ exports.startPhantom = function (args, onData, onExit) {
     });
     return phantomProcess;
 };
-
 
 var execPath = path.join(__dirname, '../bin/attester.js');
 exports.runFromCommandLine = function (options, onExit) {


### PR DESCRIPTION
1) Try to reboot Phantom instance (3 times) if it died from recoverable error
2) Exit attester when all PhantomJS instances died without hope to recover

This fixes the following issues:
- In case it was impossible to connect to attester by PhantomJS
  instance within specified timeout, the phantom process was exiting,
  but without propagating the error to attester.
  Now it propagates the error, and additionally the timeout was increased
- Now once the page emits `DOMContentLoaded`, the timeout starts from zero
- If all PhantomJS processes die (i.e. exit with code != 0) for any reason,
  now this is caught and makes attester exit with non-zero code too.
- Also, Phantom instances now have deterministic ids from 1 to N.
