### PR TITLE
Custom test types

### DIFF
--- a/lib/attester.js
+++ b/lib/attester.js
@@ -66,7 +66,7 @@ attester.start = function () {
 };
 
 // Modules are required following the order, but they should loosely depend on each other
-var allModules = ["event", "logger", "config", "reports", "middlewares", "launcher", "server", "campaign", "core", "testPage", "plugins"];
+var allModules = ["event", "logger", "config", "reports", "middlewares", "classes", "utils", "launcher", "server", "campaign", "core", "testPage", "plugins"];
 exposeModules.apply(this, allModules);
 
 // attester.package will be our package.json

--- a/lib/attester/classes.js
+++ b/lib/attester/classes.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This is a shortcut module to expose internal classes for extensibility
+ */
+
+exports.BaseTestType = require("../test-type/base-test-type");
+exports.FileSet = require("../util/files/fileSet");
+exports.Enumerator = require("../util/files/enumerator");
+exports.Logger = require("../logging/logger");

--- a/lib/attester/utils.js
+++ b/lib/attester/utils.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This is a shortcut module to expose utility methods
+ */
+
+exports.merge = require("../util/merge");
+exports.url = require("../util/url");

--- a/lib/test-type/all-tests.js
+++ b/lib/test-type/all-tests.js
@@ -17,9 +17,25 @@ var connect = require('connect');
 var url = require('../util/url');
 var Logger = require('../logging/logger.js');
 
-var testTypePrototypes = {
-    'aria-templates': require('./aria-templates/at-test-type'),
-    'mocha': require('./mocha/mocha-test-type')
+var getPrototype = function (type) {
+    // See if we can get it from local repository, otherwise delegate to npm
+    var locals = {
+        'aria-templates': './aria-templates/at-test-type',
+        'mocha': './mocha/mocha-test-type'
+    };
+
+    var module;
+    if (locals.hasOwnProperty(type)) {
+        module = require(locals[type]);
+    } else {
+        try {
+            module = require('attester-' + type);
+        } catch (ex) {}
+    }
+
+    if (module) {
+        return module(require("../attester"));
+    }
 };
 
 var AllTests = function (campaign, config, parentLogger) {
@@ -32,9 +48,10 @@ var AllTests = function (campaign, config, parentLogger) {
 
     var testTypesCount = 0;
     for (var type in config) {
-        if (testTypePrototypes.hasOwnProperty(type)) {
+        var testTypePrototype = getPrototype(type);
+        if (testTypePrototype) {
             testTypesCount++;
-            var curTestType = new testTypePrototypes[type](campaign, config[type]);
+            var curTestType = new testTypePrototype(campaign, config[type]);
             testTypes[type] = curTestType;
             app.use(curTestType.getHandler());
         } else {
@@ -179,6 +196,13 @@ AllTests.prototype.init = function (callback) {
 };
 
 AllTests.prototype.dispose = function () {
+    for (var type in this.testTypes) {
+        var instance = this.testTypes[type];
+        if (instance.dispose) {
+            this.logger.logDebug("Disposing test type '%s'.", [type]);
+            instance.dispose();
+        }
+    }
     this.logger.dispose();
 };
 

--- a/lib/test-type/aria-templates/at-test-type.js
+++ b/lib/test-type/aria-templates/at-test-type.js
@@ -16,103 +16,104 @@
 var util = require('util');
 var path = require('path');
 
-var BaseTestType = require('../base-test-type.js');
-var TestsEnumerator = require('./at-tests-enumerator.js');
+module.exports = function (attester) {
+    var BaseTestType = attester.classes.BaseTestType;
+    var TestsEnumerator = require('./at-tests-enumerator.js');
 
-var url = require('../../util/url.js');
-var merge = require('../../util/merge.js');
-var attester = require('../../attester');
+    var url = attester.utils.url;
+    var merge = attester.utils.merge;
 
-var sendAttesterTestSuite = function (req, res, next) {
-    var output = ['Aria.classDefinition({$classpath:"MainTestSuite",$extends:"aria.jsunit.TestSuite",$constructor:function(){this.$TestSuite.constructor.call(this);\n'];
-    var testCases = this.testCases;
-    for (var i = 0, l = testCases.length; i < l; i++) {
-        var curTest = testCases[i];
-        output.push('this.addTests(', JSON.stringify(curTest.name), ');\n');
-    }
-    output.push('}});');
-    res.setHeader('Content-Type', 'text/javascript');
-    res.write(output.join(''));
-    res.end();
-};
-
-var AriaTemplatesTests = function (campaign, inputConfig) {
-    // Default values for the config:
-    var testConfig = {
-        rootFolderPath: '/',
-        bootstrap: null,
-        // the default value depends on the rootFolderPath, that's why it is processed later
-        // moreover, it can be an array (legacy mode) or an object with "before" and "after" arrays, hence we can't make it an array here
-        extraScripts: null,
-        debug: true,
-        memCheckMode: true,
-        classpaths: {
-            includes: [],
-            excludes: []
-        },
-        files: {
-            includes: [],
-            excludes: []
+    var sendAttesterTestSuite = function (req, res, next) {
+        var output = ['Aria.classDefinition({$classpath:"MainTestSuite",$extends:"aria.jsunit.TestSuite",$constructor:function(){this.$TestSuite.constructor.call(this);\n'];
+        var testCases = this.testCases;
+        for (var i = 0, l = testCases.length; i < l; i++) {
+            var curTest = testCases[i];
+            output.push('this.addTests(', JSON.stringify(curTest.name), ');\n');
         }
+        output.push('}});');
+        res.setHeader('Content-Type', 'text/javascript');
+        res.write(output.join(''));
+        res.end();
     };
-    merge(testConfig, inputConfig);
-    if (!testConfig.bootstrap) {
-        testConfig.bootstrap = testConfig.rootFolderPath + 'aria/bootstrap.js';
-    }
 
-    BaseTestType.call(this, campaign, testConfig);
-    var rootFolderPath = testConfig.rootFolderPath;
+    var AriaTemplatesTests = function (campaign, inputConfig) {
+        // Default values for the config:
+        var testConfig = {
+            rootFolderPath: '/',
+            bootstrap: null,
+            // the default value depends on the rootFolderPath, that's why it is processed later
+            // moreover, it can be an array (legacy mode) or an object with "before" and "after" arrays, hence we can't make it an array here
+            extraScripts: null,
+            debug: true,
+            memCheckMode: true,
+            classpaths: {
+                includes: [],
+                excludes: []
+            },
+            files: {
+                includes: [],
+                excludes: []
+            }
+        };
+        merge(testConfig, inputConfig);
+        if (!testConfig.bootstrap) {
+            testConfig.bootstrap = testConfig.rootFolderPath + 'aria/bootstrap.js';
+        }
 
-    var ariaConfig = {
-        memCheckMode: testConfig.memCheckMode,
-        debug: testConfig.debug,
-        rootFolderPath: url.normalize(this.campaign.baseURL, rootFolderPath) + "/"
+        BaseTestType.call(this, campaign, testConfig);
+        var rootFolderPath = testConfig.rootFolderPath;
+
+        var ariaConfig = {
+            memCheckMode: testConfig.memCheckMode,
+            debug: testConfig.debug,
+            rootFolderPath: url.normalize(this.campaign.baseURL, rootFolderPath) + "/"
+        };
+        this.ariaConfig = ariaConfig;
+        this.bootstrap = testConfig.bootstrap;
+
+        this._testsEnumerator = new TestsEnumerator({
+            resources: campaign.resources,
+            files: testConfig.files,
+            classpaths: testConfig.classpaths,
+            rootFolderPath: testConfig.rootFolderPath
+        }, this.campaign.logger, attester);
+
+        this.testPage("test.html", require("./templates/test-page.json"));
+        this.testPage("interactive.html", require("./templates/interactive.json"));
+        this.use((function (req, res, next) {
+            if (/^\/MainTestSuite\.js(\?|$)/.test(req.url)) { // to allow timestamped requests
+                sendAttesterTestSuite.call(this, req, res, next);
+            } else {
+                next();
+            }
+        }).bind(this));
+        this.use(attester.middlewares.staticFolder(path.join(__dirname, 'client')));
     };
-    this.ariaConfig = ariaConfig;
-    this.bootstrap = testConfig.bootstrap;
 
-    this._testsEnumerator = new TestsEnumerator({
-        resources: campaign.resources,
-        files: testConfig.files,
-        classpaths: testConfig.classpaths,
-        rootFolderPath: testConfig.rootFolderPath
-    }, this.campaign.logger);
+    util.inherits(AriaTemplatesTests, BaseTestType);
 
-    this.testPage("test.html", require("./templates/test-page.json"));
-    this.testPage("interactive.html", require("./templates/interactive.json"));
-    this.use((function (req, res, next) {
-        if (/^\/MainTestSuite\.js(\?|$)/.test(req.url)) { // to allow timestamped requests
-            sendAttesterTestSuite.call(this, req, res, next);
-        } else {
-            next();
-        }
-    }).bind(this));
-    this.use(attester.middlewares.staticFolder(path.join(__dirname, 'client')));
+    AriaTemplatesTests.prototype.name = "Aria Templates tests";
+    AriaTemplatesTests.prototype.type = "aria-templates";
+    AriaTemplatesTests.prototype.debug = "interactive.html#runIsolated=true";
+
+    AriaTemplatesTests.prototype.init = function (callback) {
+        var self = this;
+        var testsEnumerator = self._testsEnumerator;
+        testsEnumerator.init(function () {
+            self.testsTrees = self._testsEnumerator.testsTrees;
+            var tests = testsEnumerator.testCases;
+            self.testCases = tests;
+            for (var i = 0, l = tests.length; i < l; i++) {
+                var curTest = tests[i];
+                curTest.url = 'test.html?testClasspath=' + encodeURIComponent(curTest.name);
+            }
+            callback();
+        });
+    };
+
+    AriaTemplatesTests.prototype.dispose = function (baseURL) {
+        this._testsEnumerator.dispose();
+    };
+
+    return AriaTemplatesTests;
 };
-
-util.inherits(AriaTemplatesTests, BaseTestType);
-
-AriaTemplatesTests.prototype.name = "Aria Templates tests";
-AriaTemplatesTests.prototype.type = "aria-templates";
-AriaTemplatesTests.prototype.debug = "interactive.html#runIsolated=true";
-
-AriaTemplatesTests.prototype.init = function (callback) {
-    var self = this;
-    var testsEnumerator = self._testsEnumerator;
-    testsEnumerator.init(function () {
-        self.testsTrees = self._testsEnumerator.testsTrees;
-        var tests = testsEnumerator.testCases;
-        self.testCases = tests;
-        for (var i = 0, l = tests.length; i < l; i++) {
-            var curTest = tests[i];
-            curTest.url = 'test.html?testClasspath=' + encodeURIComponent(curTest.name);
-        }
-        callback();
-    });
-};
-
-AriaTemplatesTests.prototype.dispose = function (baseURL) {
-    this._testsEnumerator.dispose();
-};
-
-module.exports = AriaTemplatesTests;

--- a/lib/test-type/aria-templates/at-tests-enumerator.js
+++ b/lib/test-type/aria-templates/at-tests-enumerator.js
@@ -16,8 +16,6 @@
 var util = require('util');
 
 var ATEnvironment = require('./at-environment.js');
-var FileSet = require('../../util/files/fileset.js');
-var Logger = require('../../logging/logger.js');
 
 var arrayToMap = function (array) {
     var map = {};
@@ -39,10 +37,10 @@ var formatError = function (error) {
     return msg;
 };
 
-var TestEnumerator = function (config, logger) {
-    this.logger = new Logger('TestEnumerator', logger);
+var TestEnumerator = function (config, logger, attester) {
+    this.logger = new attester.classes.Logger('TestEnumerator', logger);
     if (config.files) {
-        this.fileSet = new FileSet(config.files);
+        this.fileSet = new attester.classes.FileSet(config.files);
     }
     this.atEnvironment = new ATEnvironment({
         resources: config.resources,

--- a/lib/test-type/mocha/mocha-test-type.js
+++ b/lib/test-type/mocha/mocha-test-type.js
@@ -16,128 +16,131 @@
 var util = require('util');
 var path = require('path');
 
-var BaseTestType = require('../base-test-type.js');
-var FileSet = require('../../util/files/fileset');
+module.exports = function (attester) {
+    var BaseTestType = attester.classes.BaseTestType;
+    var FileSet = attester.classes.FileSet;
 
-var merge = require('../../util/merge.js');
-var attester = require('../../attester');
+    var merge = attester.utils.merge;
 
-/**
- * Send a test page, this is doing something only when serving test.html
- * In that case the page that looks like http://visionmedia.github.com/mocha/#browser-support
- *
- * The other resources are inside this.getBaseURL() and are structured as so
- * - lib/        Mocha lib files
- * - client/     Client files needed to connect to attester
- * - assertion/  Assertion libraries
- * - tests/      User defined test files
- */
+    /**
+     * Send a test page, this is doing something only when serving test.html
+     * In that case the page that looks like http://visionmedia.github.com/mocha/#browser-support
+     *
+     * The other resources are inside this.getBaseURL() and are structured as so
+     * - lib/        Mocha lib files
+     * - client/     Client files needed to connect to attester
+     * - assertion/  Assertion libraries
+     * - tests/      User defined test files
+     */
+    var staticFile = attester.middlewares.staticFile;
+    var staticFolder = attester.middlewares.staticFolder;
 
 
-/**
- * Generates the configuration object for mocha.setup()
- */
-var buildSetupConfig = function (config) {
-    var options = {
-        ui: config.ui
+    /**
+     * Generates the configuration object for mocha.setup()
+     */
+    var buildSetupConfig = function (config) {
+        var options = {
+            ui: config.ui
+        };
+        if (config.ignoreLeaks === true) {
+            // because of https://github.com/visionmedia/mocha/pull/781 we cannot set
+            // ignoreLeaks : false
+            options.ignoreLeaks = true;
+        }
+        if (config.globals.length !== 0) {
+            options.globals = config.globals.slice();
+        }
+        return JSON.stringify(options);
     };
-    if (config.ignoreLeaks === true) {
-        // because of https://github.com/visionmedia/mocha/pull/781 we cannot set
-        // ignoreLeaks : false
-        options.ignoreLeaks = true;
-    }
-    if (config.globals.length !== 0) {
-        options.globals = config.globals.slice();
-    }
-    return JSON.stringify(options);
-};
 
-var MochaTestType = function (campaign, inputConfig) {
-    // Default values for the configuration object
-    var testConfig = {
-        files: {
-            rootDirectory: process.cwd(),
-            includes: [],
-            excludes: []
-        },
-        extraScripts: null,
-        // could be either array or object
-        ui: "bdd",
-        ignoreLeaks: false,
-        globals: [],
-        assertion: "expect"
+    var MochaTestType = function (campaign, inputConfig) {
+        // Default values for the configuration object
+        var testConfig = {
+            files: {
+                rootDirectory: process.cwd(),
+                includes: [],
+                excludes: []
+            },
+            extraScripts: null,
+            // could be either array or object
+            ui: "bdd",
+            ignoreLeaks: false,
+            globals: [],
+            assertion: "expect"
+        };
+        merge(testConfig, inputConfig);
+
+        BaseTestType.call(this, campaign, testConfig);
+        this.config.mochaSetup = buildSetupConfig(testConfig);
+
+        // I have to do this because then I modify the description
+        var testDescription = {
+            head: [],
+            body: []
+        };
+        var interactiveDescription = {
+            head: [],
+            body: []
+        };
+        merge(testDescription, require("./templates/test-page.json"));
+        merge(interactiveDescription, require("./templates/interactive.json"));
+
+        this.use("lib", staticFolder(path.dirname(require.resolve("mocha"))));
+        this.use("client", staticFolder(path.join(__dirname, "client")));
+        this.use("tests", staticFolder(path.join(__dirname, path.relative(__dirname, testConfig.files.rootDirectory))));
+
+        var assertion = testConfig.assertion;
+        var assertionDescription = {
+            tagName: "script"
+        };
+        if (/^expect([\.\-]?js)?$/.test(assertion)) {
+            assertionDescription.src = this.getBaseURL() + "/assertion/expect.js";
+            this.use(staticFile.bind({
+                page: "/assertion/expect.js",
+                path: path.join(path.dirname(require.resolve("expect.js")), "expect.js")
+            }));
+        } else if (/chai(\.js)?/.test(assertion)) {
+            assertionDescription.src = this.getBaseURL() + "/assertion/chai.js";
+            this.use(staticFile.bind({
+                page: "/assertion/chai.js",
+                path: path.join(path.dirname(require.resolve("chai")), "chai.js")
+            }));
+        } else {
+            // I hope the use gave a valid path for the assertion library
+            assertionDescription.src = assertion;
+        }
+
+        testDescription.head.push(assertionDescription);
+        interactiveDescription.head.push(assertionDescription);
+
+        // Two test pages, one for automatic testing, one for interactive
+        this.testPage("test.html", testDescription);
+        this.testPage("interactive.html", interactiveDescription);
     };
-    merge(testConfig, inputConfig);
 
-    BaseTestType.call(this, campaign, testConfig);
-    this.config.mochaSetup = buildSetupConfig(testConfig);
+    util.inherits(MochaTestType, BaseTestType);
 
-    // I have to do this because then I modify the description
-    var testDescription = {
-        head: [],
-        body: []
-    };
-    var interactiveDescription = {
-        head: [],
-        body: []
-    };
-    merge(testDescription, require("./templates/test-page.json"));
-    merge(interactiveDescription, require("./templates/interactive.json"));
+    MochaTestType.prototype.name = "Mocha Test";
+    MochaTestType.prototype.type = "mocha";
+    MochaTestType.prototype.debug = "interactive.html";
 
-    this.use("lib", attester.middlewares.staticFolder(path.dirname(require.resolve("mocha"))));
-    this.use("client", attester.middlewares.staticFolder(path.join(__dirname, "client")));
-    this.use("tests", attester.middlewares.staticFolder(path.join(__dirname, path.relative(__dirname, testConfig.files.rootDirectory))));
-
-    var assertion = testConfig.assertion;
-    var assertionDescription = {
-        tagName: "script"
-    };
-    if (/^expect([\.\-]?js)?$/.test(assertion)) {
-        assertionDescription.src = this.getBaseURL() + "/assertion/expect.js";
-        this.use(attester.middlewares.staticFile.bind({
-            page: "/assertion/expect.js",
-            path: path.join(path.dirname(require.resolve("expect.js")), "expect.js")
-        }));
-    } else if (/chai(\.js)?/.test(assertion)) {
-        assertionDescription.src = this.getBaseURL() + "/assertion/chai.js";
-        this.use(attester.middlewares.staticFile.bind({
-            page: "/assertion/chai.js",
-            path: path.join(path.dirname(require.resolve("chai")), "chai.js")
-        }));
-    } else {
-        // I hope the use gave a valid path for the assertion library
-        assertionDescription.src = assertion;
-    }
-
-    testDescription.head.push(assertionDescription);
-    interactiveDescription.head.push(assertionDescription);
-
-    // Two test pages, one for automatic testing, one for interactive
-    this.testPage("test.html", testDescription);
-    this.testPage("interactive.html", interactiveDescription);
-};
-
-util.inherits(MochaTestType, BaseTestType);
-
-MochaTestType.prototype.name = "Mocha Test";
-MochaTestType.prototype.type = "mocha";
-MochaTestType.prototype.debug = "interactive.html";
-
-/**
- * Initialize this test script by extending the file sets in the configuration object.
- * @param {Function} callback
- */
-MochaTestType.prototype.init = function (callback) {
-    var testType = this;
-    var files = new FileSet(this.config.files);
-    files.iterate(function (filePath) {
-        testType.testsTrees.push({
-            name: filePath,
-            url: "test.html?name=" + encodeURIComponent(filePath)
+    /**
+     * Initialize this test script by extending the file sets in the configuration object.
+     * @param {Function} callback
+     */
+    MochaTestType.prototype.init = function (callback) {
+        var testType = this;
+        var files = new FileSet(this.config.files);
+        files.iterate(function (filePath) {
+            testType.testsTrees.push({
+                name: filePath,
+                url: "test.html?name=" + encodeURIComponent(filePath)
+            });
+        }, function () {
+            callback();
         });
-    }, function () {
-        callback();
-    });
-};
+    };
 
-module.exports = MochaTestType;
+    return MochaTestType;
+};

--- a/spec/test-type/mocha/moca-reader.spec.js
+++ b/spec/test-type/mocha/moca-reader.spec.js
@@ -15,6 +15,7 @@
 
 describe("Mocha test type", function () {
     var mochaTestType = require('../../../lib/test-type/mocha/mocha-test-type.js');
+    mochaTestType = mochaTestType(require("../../../lib/attester"));
 
     it("should build the correct list of tests", function (callback) {
         var config = {


### PR DESCRIPTION
Change the way test types are loaded in order to allow creating custom plugins.
The logic now is the following
- try to resolve the test type inside the repository
- if missing require `attester-type`

The diff looks horrible, but in `at-test-type` and `mocha-test-type` I've simply indented the code.

The base change is

BEFORE

``` js
var BaseTestType = require("../base-test-type");
var MyTestType = function () {};
util.inherits(MyTestType, BaseTestType);
module.exports = MyTestType;
```

AFTER

``` js
module.exports = function (attester) {
var BaseTestType = attester.classes.BaseTestType;
var MyTestType = function () {};
util.inherits(MyTestType, BaseTestType);
return MyTestType;
};
```

In short, I've removed any `require()` of files outside of test-type folder.

Eventually the two test types in this repo can be moved to their own repository, it's enough to call them `attester-aria-templates` and `attester-mocha`, then the user can put what she needs inside `package.json`

The structure of test types resembles that of grunt plugins.
