### PR TITLE
Bump some dependencies

### DIFF
--- a/lib/middlewares/resources.js
+++ b/lib/middlewares/resources.js
@@ -132,10 +132,14 @@ Resources.prototype.staticSender = function () {
         var resolvedPath = req.resolvedPath;
         if (resolvedPath) {
             var error = function error(err) {
-                if (404 == err.status) return next();
+                if (404 == err.status) {
+                    return next();
+                }
                 next(err);
             };
-            send(req, encodeURIComponent(resolvedPath.pathInContext)).root(resolvedPath.contextRoot).on('error', error).pipe(res);
+            send(req, encodeURIComponent(resolvedPath.pathInContext), {
+                root: resolvedPath.contextRoot
+            }).on('error', error).pipe(res);
         } else {
             next();
         }

--- a/package.json
+++ b/package.json
@@ -8,43 +8,56 @@
         "type": "git",
         "url": "git://github.com/ariatemplates/attester.git"
     },
+    "bugs": {
+        "url": "https://github.com/attester/attester/issues"
+    },
+    "keywords": [
+        "js",
+        "javascript",
+        "testing",
+        "test",
+        "runner",
+        "test-runner",
+        "remote"
+    ],
+    "license": "Apache-2.0",
     "bin": {
         "attester": "bin/attester.js"
     },
     "main": "./lib/attester.js",
     "dependencies": {
-        "colors": "0.6.1",
-        "connect": "2.7.8",
-        "eventemitter2": "0.4.13",
+        "colors": "0.6.2",
+        "connect": "2.25.7",
+        "eventemitter2": "0.4.14",
         "exit": "0.1.2",
-        "js-yaml": "2.1.0",
+        "js-yaml": "3.1.0",
         "lodash": "1.3.1",
         "minimatch": "0.2.12",
         "node-coverage": "1.0.7",
-        "noder-js": "1.2.1",
-        "optimist": "0.6.0",
+        "noder-js": "1.6.0",
+        "optimist": "0.6.1",
         "portfinder": "0.2.1",
         "q": "1.0.0",
         "selenium-java-robot": "0.0.4",
-        "send": "0.1.0",
+        "send": "0.9.3",
         "socket.io": "0.9.16",
         "ua-parser-snapshot": "0.3.201404031741",
-        "uglify-js": "2.4.12"
+        "uglify-js": "2.4.15"
     },
     "devDependencies": {
         "ariatemplates": "1.5.4",
-        "chai": "1.7.2",
+        "chai": "1.9.1",
         "expect.js": "0.2.0",
-        "grunt": "0.4.1",
+        "grunt": "0.4.5",
         "grunt-beautify": "git+https://github.com/ariatemplates/grunt-beautify.git#grunt4",
-        "grunt-cli": "0.1.9",
+        "grunt-cli": "0.1.13",
         "grunt-contrib-jshint": "0.10.0",
-        "grunt-contrib-watch": "0.4.4",
+        "grunt-contrib-watch": "0.6.1",
         "grunt-jasmine-node": "0.1.0",
         "jasmine-node": "1.14.5",
         "mocha": "1.8.1",
-        "xml2js": "0.2.8",
-        "rimraf": "2.2.2"
+        "rimraf": "2.2.8",
+        "xml2js": "0.4.4"
     },
     "scripts": {
         "test": "node grunt-cli test"


### PR DESCRIPTION
https://gemnasium.com/attester/attester

Seems most of the deps are outdated, let's update some of them

However some new versions of the dependencies break the build:

mocha 1.21.4
expect 0.3.1
ariatemplates 1.6.3

There are more that I haven't tested yet, but have mostly changed the first digit, so incompatibilities are to be expected.

TODO:
- [x] `send` logs some deprecations (see https://github.com/visionmedia/send/blob/master/History.md) 
