### PR TITLE
Task restart mechanism when a browser is disconnected

### DIFF
--- a/bin/attester.js
+++ b/bin/attester.js
@@ -32,6 +32,7 @@ var opt = optimist.usage('Usage: $0 [options] [config.yml|config.json]').boolean
     'ignore-failures': 'When enabled, test failures (anticipated errors) will not cause this process to return a non-zero value.',
     'json-console': 'When enabled, JSON objects will be sent to stdout to provide information about tests.',
     'log-level': 'Level of logging: integer from 0 (no logging) to 4 (debug).',
+    'max-task-restarts': 'Maximum number of times a task can be restarted (after being interrupted by a browser disconnection).',
     'phantomjs-instances': 'Number of instances of PhantomJS to start.',
     'phantomjs-path': 'Path to PhantomJS executable.',
     'port': 'Port used for the web server. If set to 0, an available port is automatically selected.',

--- a/lib/attester/config.js
+++ b/lib/attester/config.js
@@ -32,6 +32,7 @@ exports.getDefaults = function () {
         'ignore-errors': false,
         'ignore-failures': false,
         'log-level': 3,
+        'max-task-restarts': 1,
         'phantomjs-instances': process.env.npm_package_config_phantomjsInstances || 0,
         'phantomjs-path': 'phantomjs',
         'port': 7777,
@@ -69,7 +70,7 @@ exports.readFile = function (configFile, logger) {
 
 /**
  * Set the global configuration of attester.
- * 
+ *
  * If only one parameter is specified it merges this object into the attester configuration
  *
  * If two parameters are given, the first must be a string specifying the first level key.

--- a/lib/attester/server.js
+++ b/lib/attester/server.js
@@ -71,7 +71,8 @@ exports.create = function (callback) {
         frozen: config["server-only"],
         flashPolicyPort: config["flash-policy-port"],
         flashPolicyServer: config["flash-policy-server"],
-        taskTimeout: config["task-timeout"]
+        taskTimeout: config["task-timeout"],
+        maxTaskRestarts: config["max-task-restarts"]
     }, attester.logger);
     testServer.server.on("error", function (error) {
         testServer.logger.logError("Web server error: %s", [error]);

--- a/lib/reports/console-report.js
+++ b/lib/reports/console-report.js
@@ -45,6 +45,9 @@ var eventTypes = {
         }
     },
     taskFinished: function (event) {
+        if (event.restartPlanned) {
+            this.logger.logWarn("%s will be restarted", [event.taskName]);
+        }
         if (event.browserRemainingTasks === 0) {
             this.logger.logInfo("All tasks finished for browser: ", [event.browserName || "default browser"]);
         }

--- a/lib/reports/json-report.js
+++ b/lib/reports/json-report.js
@@ -24,6 +24,9 @@ function JsonReport() {
         tasksIgnored: 0,
         tasksStarted: 0,
         tasksFinished: 0,
+        tasksRestarts: 0,
+        tasksSuccess: 0,
+        tasksError: 0,
         testsStarted: 0,
         testsFinished: 0,
         testCases: 0,
@@ -94,7 +97,7 @@ function processTasksList(tasks) {
 function getRunningTask(event) {
     var taskId = event.taskId;
     var task = this.tasks[taskId];
-    if (!task || !task.startTime || task.endTime) {
+    if (!task || !task.events) {
         // TODO: error
         return;
     }
@@ -114,7 +117,7 @@ var eventTypes = {
             return;
         }
         task.startTime = event.time;
-        task.runningTests = {};
+        task.events = [];
         this.stats.tasksStarted++;
     },
     taskFinished: function taskFinished(event) {
@@ -122,7 +125,17 @@ var eventTypes = {
         if (!task) {
             return;
         }
-        delete task.runningTests;
+        var events = task.events;
+        delete task.events;
+        if (event.restartPlanned) {
+            // undo what was done in taskStarted:
+            delete task.startTime;
+            this.stats.tasksStarted--;
+            // counts the number of tasks restarts:
+            this.stats.tasksRestarts++;
+            return;
+        }
+        processTaskEvents.call(this, task, events);
         task.endTime = event.time;
         task.duration = task.endTime - task.startTime;
         addToFlatReport.call(this, task);
@@ -143,11 +156,13 @@ var eventTypes = {
         addToFlatReport.call(this, task);
         this.stats.tasksIgnored++;
     },
-    testStarted: function testStarted(event) {
-        var task = getRunningTask.call(this, event);
-        if (!task) {
-            return;
-        }
+    testStarted: queueTaskEvent,
+    testFinished: queueTaskEvent,
+    error: queueTaskEvent
+};
+
+var queuedEventTypes = {
+    testStarted: function testStarted(task, event, runningTests) {
         var parent = task;
         var test = {
             name: event.name,
@@ -155,7 +170,7 @@ var eventTypes = {
         };
         var parentId = event.parentTestId;
         if (parentId) {
-            parent = task.runningTests[parentId] || task;
+            parent = runningTests[parentId] || task;
         }
         if (event.method) {
             test.method = event.method;
@@ -169,15 +184,11 @@ var eventTypes = {
             parent.subTests = [];
         }
         parent.subTests.push(test);
-        task.runningTests[event.testId] = test;
+        runningTests[event.testId] = test;
         this.stats.testsStarted++;
     },
-    testFinished: function testFinished(event) {
-        var task = getRunningTask.call(this, event);
-        if (!task) {
-            return;
-        }
-        var test = task.runningTests[event.testId];
+    testFinished: function testFinished(task, event, runningTests) {
+        var test = runningTests[event.testId];
         test.asserts = event.asserts;
         if (event.asserts) {
             this.stats.asserts += event.asserts;
@@ -186,14 +197,10 @@ var eventTypes = {
         test.duration = event.duration;
         this.stats.testsFinished++;
     },
-    error: function error(event) {
-        var task = getRunningTask.call(this, event);
-        if (!task) {
-            return;
-        }
+    error: function error(task, event, runningTests) {
         var parent = task;
         if (event.testId) {
-            parent = task.runningTests[event.testId] || task;
+            parent = runningTests[event.testId] || task;
         }
         if (!parent.errors) {
             parent.errors = [];
@@ -207,6 +214,32 @@ var eventTypes = {
         }
     }
 };
+
+function queueTaskEvent(event) {
+    var task = getRunningTask.call(this, event);
+    if (!task) {
+        return;
+    }
+    task.events.push(event);
+}
+
+function processTaskEvents(task, events) {
+    var runningTests = {};
+    var error = false;
+    for (var i = 0, l = events.length; i < l; i++) {
+        var curEvent = events[i];
+        var eventName = curEvent.event;
+        if (eventName == "error") {
+            error = true;
+        }
+        queuedEventTypes[eventName].call(this, task, curEvent, runningTests);
+    }
+    if (error) {
+        this.stats.tasksError++;
+    } else {
+        this.stats.tasksSuccess++;
+    }
+}
 
 JsonReport.prototype = {};
 

--- a/lib/test-campaign/test-campaign.js
+++ b/lib/test-campaign/test-campaign.js
@@ -142,7 +142,7 @@ TestCampaign.prototype.addResult = function (event) {
     var eventName = event.event;
     if (eventName == "coverage") {
         this.remainingCoverageResults++;
-    } else if (eventName == "taskFinished" || eventName == "taskIgnored") {
+    } else if ((eventName == "taskFinished" && !event.restartPlanned) || eventName == "taskIgnored") {
         this.remainingTasks--;
         this.checkFinished();
     }

--- a/lib/test-server/slave-server.js
+++ b/lib/test-server/slave-server.js
@@ -36,7 +36,17 @@ var wrapInTryCatch = function (scope, fct) {
     };
 };
 
-var campaignTaskFinished = function (scope) {
+var checkRestart = function (scope, task) {
+    var restarts = task.restarts || 0;
+    restarts++;
+    if (restarts > scope.config.maxTaskRestarts) {
+        return false;
+    }
+    task.restarts = restarts;
+    return true;
+};
+
+var campaignTaskFinished = function (scope, restart) {
     var task = scope.currentTask;
     var campaign = scope.currentCampaign;
     scope.currentTask = null;
@@ -50,6 +60,10 @@ var campaignTaskFinished = function (scope) {
     };
     task.browser.onTaskFinished();
     feedEventWithTaskData(event, task);
+    event.restartPlanned = restart && checkRestart(scope, task);
+    if (event.restartPlanned) {
+        task.browser.addTask(task);
+    }
     campaign.addResult(event);
     if (scope.socket) {
         scope.socket.emit('slave-stop');
@@ -57,7 +71,7 @@ var campaignTaskFinished = function (scope) {
     }
 };
 
-var emitTaskError = function (scope, message) {
+var emitTaskError = function (scope, message, restart) {
     var task = scope.currentTask;
     if (task) {
         scope.currentCampaign.addResult({
@@ -69,7 +83,7 @@ var emitTaskError = function (scope, message) {
             },
             name: task.test.name
         });
-        campaignTaskFinished(scope);
+        campaignTaskFinished(scope, restart);
     }
 };
 
@@ -166,7 +180,7 @@ Slave.prototype.onPauseChanged = function (paused) {
 Slave.prototype.onSocketDisconnected = function () {
     if (this.socket) {
         this.socket = null;
-        emitTaskError(this, "Browser was disconnected: " + this.toString());
+        emitTaskError(this, "Browser was disconnected: " + this.toString(), true);
         this.emit('disconnect');
     }
 };
@@ -203,7 +217,7 @@ Slave.prototype.getStatus = function () {
 
 Slave.prototype.taskTimeout = function () {
     this.taskTimeoutId = null;
-    emitTaskError(this, "Task timeout.");
+    emitTaskError(this, "Task timeout.", false);
 };
 
 Slave.prototype.dispose = function (callback) {

--- a/spec/cli/cli.spec.js
+++ b/spec/cli/cli.spec.js
@@ -335,9 +335,9 @@ describe('cli', function () {
     });
 
     itRuns({
-        testCase: 'browser disconnected',
+        testCase: 'browser disconnected (no restart)',
         exitCode: 1,
-        args: ['--config.tests.mocha.files.includes', 'spec/test-type/mocha/extraScripts/disconnect.js'],
+        args: ['--max-task-restarts', '0', '--config.tests.mocha.files.includes', 'spec/test-type/mocha/extraScripts/disconnect.js'],
         results: {
             run: 1,
             failures: 0,
@@ -345,6 +345,19 @@ describe('cli', function () {
             skipped: 0
         },
         hasErrors: ["Browser was disconnected"]
+    });
+
+    itRuns({
+        testCase: 'browser disconnected (1 restart)',
+        exitCode: 1,
+        args: ['--max-task-restarts', '1', '--config.tests.mocha.files.includes', 'spec/test-type/mocha/extraScripts/disconnect.js'],
+        results: {
+            run: 1,
+            failures: 0,
+            errors: 1,
+            skipped: 0
+        },
+        hasErrors: ["Browser was disconnected", "Browser was disconnected"]
     });
 
     // There are 3 tests lasting ~1s, with a timeout of 2s everything should be fine

--- a/spec/cli/timeout.spec.js
+++ b/spec/cli/timeout.spec.js
@@ -30,7 +30,7 @@ describe('timeout', function () {
             utils.runFromCommandLine({
                 testCase: "timeout after disconnect",
                 timeout: 10000,
-                args: ['--config.tests.mocha.files.includes', 'spec/test-type/mocha/extraScripts/disconnect.js', '--config.tests.mocha.files.includes', 'spec/test-type/mocha/sample-tests/**/*Test.js', '--task-timeout', '500']
+                args: ['--max-task-restarts', '0', '--config.tests.mocha.files.includes', 'spec/test-type/mocha/extraScripts/disconnect.js', '--config.tests.mocha.files.includes', 'spec/test-type/mocha/sample-tests/**/*Test.js', '--task-timeout', '500']
             }, function (code, testExecution, errorMessages) {
                 attesterFinished = true;
                 expect(errorMessages.length).toEqual(1);


### PR DESCRIPTION
Currently, when a browser is disconnected, an error is raised and the current task is considered as failed.
This PR automatically queues again those interrupted tasks so that they can be tried again (with a maximum number of restarts, so that tasks which make a browser crash do not lead to a never ending campaign).
