### PR TITLE
Fixing an issue when refreshing the slave.html page on IE.

### DIFF
--- a/lib/test-server/client/slave-client.js
+++ b/lib/test-server/client/slave-client.js
@@ -158,6 +158,9 @@
     };
 
     var sendTestUpdate = function (name, info) {
+        if (!currentTask) {
+            return;
+        }
         if (!info) {
             info = {};
         }
@@ -196,6 +199,9 @@
         sendTestUpdate('error', info);
     };
     attester.taskFinished = function () {
+        if (!currentTask) {
+            return;
+        }
         socket.emit('task-finished');
     };
     attester.stackTrace = function (exception) {
@@ -231,4 +237,8 @@
 
     // Used to store methods and properties specific to the running task
     attester.currentTask = {};
+
+    // Creating an empty iframe so that IE can replace its url without any harm
+    // (when refreshing the page, IE tries to restore the previous URL of the iframe)
+    createIframe(baseUrl + location.pathname.replace(/\/[^\/]+$/, "/empty.html"));
 })();


### PR DESCRIPTION
When refreshing the `slave.html` page on IE, attester creates an iframe with the next task to be executed, but IE loads the previous URL of the iframe (trying to restore it), leading to a different task being executed on the client than the one the server thinks is being executed, leading to wrong results.

This pull request fixes the issue by first loading an empty iframe and ignoring any result until a task is sent from the server.
