### PR TITLE
Supporting node.js 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: node_js
 node_js:
- - 0.8
+ - 0.10
 before_install:
 # Changing the /etc/hosts file is needed for the selenium Firefox driver to work correctly
 # (see https://code.google.com/p/selenium/issues/detail?id=3280)
  - (echo "127.0.0.1 localhost" && cat /etc/hosts) > /tmp/hosts && sudo mv /tmp/hosts /etc/hosts
- - npm install -g npm@1.4.21
  - npm --version
  - phantomjs --version
  - export DISPLAY=:99.0

--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
         "test": "node grunt-cli test"
     },
     "engines": {
-        "node": "~0.8.3"
+        "node": "~0.10.32"
     }
 }


### PR DESCRIPTION
This PR adds support for node.js 0.10 in `.travis.yml` and `package.json`.
See #27 and #61.
