### PR TITLE
Fix for IPv6 support.

### DIFF
--- a/lib/test-server/test-server.js
+++ b/lib/test-server/test-server.js
@@ -204,8 +204,10 @@ TestServer.prototype.getURL = function (urlType) {
     }
     var address = this.server.address();
     var hostname = address.address;
-    if (address.family == 'IPv4' && hostname == '0.0.0.0') {
-        hostname = 'localhost';
+    if (address.family == 'IPv6' && hostname == '::') {
+        hostname = '::1';
+    } else if (address.family == 'IPv4' && hostname == '0.0.0.0') {
+        hostname = '127.0.0.1';
     }
     return url.format({
         protocol: 'http',


### PR DESCRIPTION
This commit fixes an issue with the URL when the server is bound to an IPv6 address.
Note that this fix is not sufficient to make attester fully support IPv6 addresses, as socket.io has some issues too.
