### PR TITLE
Removing the need to parse the task name to get the browser name

### DIFF
--- a/lib/test-type/all-tests.js
+++ b/lib/test-type/all-tests.js
@@ -79,14 +79,18 @@ var buildTask = function (testType, test, browser) {
     };
     this.tasks[taskId] = task;
     var name = test.name;
+    var browserName;
     if (browser != null) {
         browser.addTask(task);
         if (browser.name) {
+            browserName = browser.name;
             name += ' on ' + browser.name;
         }
     }
     return {
         taskId: taskId,
+        taskName: test.name,
+        browserName: browserName,
         name: name
     };
 };


### PR DESCRIPTION
This commit adds the `browserName` and `taskName` properties in the tasks list so that it is no longer needed to parse the `name` property (with the `taskName on browserName` syntax, which can sometimes be ambiguous).