### PR TITLE
Add extra data on extrascripts injected to the test page

### DIFF
--- a/lib/test-type/test-content.json
+++ b/lib/test-type/test-content.json
@@ -1,10 +1,10 @@
 {
 	"head-start": [
 		"<title><%= data.name %></title>",
-		"<% _.forEach(data.config.extraScripts.before, function (script) { %><script type=\"text/javascript\" src=\"<%= script %>\"></script><% }); %>"
+		"<% _.forEach(data.config.extraScripts.before, function (script) { %><script type=\"text/javascript\" data-extrascript=\"before\" src=\"<%= script %>\"></script><% }); %>"
 	],
 	"head-end": [
-		"<% _.forEach(data.config.extraScripts.after, function (script) { %><script type=\"text/javascript\" src=\"<%= script %>\"></script><% }); %>"
+		"<% _.forEach(data.config.extraScripts.after, function (script) { %><script type=\"text/javascript\" data-extrascript=\"after\" src=\"<%= script %>\"></script><% }); %>"
 	],
 	"body": []
 }


### PR DESCRIPTION
This commit adds extra data attributes on `<script>`s injected into test
page via `extraScripts` attester config, so that they can be propagated
further by a test submodule (for instance injected into subframes via
AT Classic Test Runner when running tests in isolated mode)