### PR TITLE
Add AriaLib to the AT interactive test page

### DIFF
--- a/lib/test-type/aria-templates/templates/interactive.json
+++ b/lib/test-type/aria-templates/templates/interactive.json
@@ -9,6 +9,10 @@
             "src": "<%= encodeURI(data.config.bootstrap) %>"
         },
         {
+            "tagName": "script",
+            "content": "aria.core.AppEnvironment.setEnvironment({defaultWidgetLibs:{'aria': 'aria.widgets.AriaLib'}});"
+        },
+        {
             "tagName": "style",
             "content": "html{overflow:hidden;}body{margin:0px;background-color:#FAFAFA;font-family:tahoma,arial,helvetica,sans-serif;font-size:11px;}"
         }


### PR DESCRIPTION
If the application under test does not declare AriaLib as its widget lib (because it does not use widgets, or uses only HtmlLib for instance), then the Classic Test Runner test page failed to load