### PR TITLE
Allowing JS plugins to be inserted client-side through the ?plugin= syntax.

### DIFF
--- a/lib/test-server/client/plugins.js
+++ b/lib/test-server/client/plugins.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+(function () {
+    var window = this;
+
+    function fixedEncodeURI(str) {
+        return encodeURI(str).replace(/%5B/g, '[').replace(/%5D/g, ']');
+    }
+
+    window.location.search.replace(/(?:\?|\&)plugin=([^&]*)/g, function (match, plugin) {
+        var url = decodeURIComponent(plugin);
+        window.document.write('<script src="' + fixedEncodeURI(url) + '"></script>');
+        return "";
+    });
+})();

--- a/lib/test-server/client/slave.html
+++ b/lib/test-server/client/slave.html
@@ -22,6 +22,7 @@
 	</div>
 	<script src="json3/json3.min.js"></script>
 	<script src="/socket.io/socket.io.js"></script>
+	<script src="plugins.js"></script>
 	<script src="slave-client.js"></script>
 	<script src="stacktrace.js"></script>
 </body>

--- a/lib/test-type/testPage.html
+++ b/lib/test-type/testPage.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width">
     <script type="text/javascript" src="/__attester__/iframe.js"></script>
+    <script type="text/javascript" src="/__attester__/plugins.js"></script>
     <%= head %>
 </head>
 <body>


### PR DESCRIPTION
This commit adds the "plugin" URL parameter which allows to add any JavaScript file in the test page to extend the features of attester.