### PR TITLE
Allowing the host to be configured, defaulting to 0.0.0.0.

### DIFF
--- a/bin/attester.js
+++ b/bin/attester.js
@@ -34,6 +34,7 @@ var opt = optimist.usage('Usage: $0 [options] [config.yml|config.json]').boolean
     'phantomjs-instances': 'Number of instances of PhantomJS to start.',
     'phantomjs-path': 'Path to PhantomJS executable.',
     'port': 'Port used for the web server. If set to 0, an available port is automatically selected.',
+    'host': 'Host used for the web server.',
     'predictable-urls': 'If true, resources served by the campaign have predictable URLs (campaign1, campaign2...). Otherwise, the campaign part in the URL is campaign ID. Useful for debugging.',
     'robot-browser': 'Specifies the browser that should be automatically started by the selenium-java-robot (either Firefox, Chrome, Safari or Internet Explorer).',
     'run-browser': 'Path to any browser executable to execute the tests. Can be repeated multiple times.',

--- a/lib/attester/config.js
+++ b/lib/attester/config.js
@@ -38,6 +38,7 @@ exports.getDefaults = function () {
         'phantomjs-instances': process.env.npm_package_config_phantomjsInstances || 0,
         'phantomjs-path': 'phantomjs',
         'port': 7777,
+        'host': '0.0.0.0',
         'predictable-urls': false,
         'shutdown-on-campaign-end': true,
         'slow-test-threshold': 2500,

--- a/lib/attester/server.js
+++ b/lib/attester/server.js
@@ -80,8 +80,10 @@ exports.create = function (callback) {
         attester.event.emit("server.error");
     });
 
-    portfinder.basePort = config.port;
-    portfinder.getPort(function (err, port) {
+    portfinder.getPort({
+        port: config.port,
+        host: config.host
+    }, function (err, port) {
         if (err) {
             attester.event.emit("server.error", "Can't start the server: %s", [err]);
             return;
@@ -90,7 +92,7 @@ exports.create = function (callback) {
             // logging error instead of a warning so it's more visible in the console
             attester.logger.logError("Port %d unavailable; using %d instead.", [config.port, port]);
         }
-        testServer.server.listen(port, function () {
+        testServer.server.listen(port, config.host, function () {
             testServerReady = true;
             attester.event.emit("server.listening");
             callback();

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "node-coverage": "1.0.7",
         "noder-js": "1.6.0",
         "optimist": "0.6.1",
-        "portfinder": "0.2.1",
+        "portfinder": "0.4.0",
         "q": "1.0.1",
         "selenium-java-robot": "0.0.6",
         "semver": "2.3.1",


### PR DESCRIPTION
This also fixes an issue with node 0.12.x which, by default, uses an IPv6 address and makes socket.io fail.