### PR TITLE
Adding support for slave controllers.

### DIFF
--- a/lib/test-server/client/slave-client.js
+++ b/lib/test-server/client/slave-client.js
@@ -36,6 +36,13 @@
     var testInfo = "loading";
     var currentTask = null;
     var pendingTestStarts = null;
+    var slaveId = (function () {
+        var match = /(?:\?|\&)id=([^&]+)/.exec(location.search);
+        if (match) {
+            return match[1];
+        }
+        return null;
+    })();
     var beginning = new Date();
 
     var log = window.location.search.indexOf("log=true") !== -1 ?
@@ -105,6 +112,7 @@
         stop();
         socket.emit('hello', {
             type: 'slave',
+            id: slaveId,
             paused: paused,
             userAgent: window.navigator.userAgent,
             documentMode: document.documentMode

--- a/lib/test-server/slave-controller.js
+++ b/lib/test-server/slave-controller.js
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2015 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var crypto = require("crypto");
+var idNumber = 0;
+
+var createSlaveId = function () {
+    idNumber++;
+    return idNumber + "-" + new Buffer(crypto.pseudoRandomBytes(8)).toString("hex");
+};
+
+var SlaveController = module.exports = function (socket, data, testServer) {
+    this.socket = socket;
+    this.testServer = testServer;
+    this.slavesInfo = {};
+    this.onCommandSlaveCreate = this.onCommandSlaveCreate.bind(this);
+    this.onCommandSlaveDelete = this.onCommandSlaveDelete.bind(this);
+    this.onCommandStatus = this.onCommandStatus.bind(this);
+    this.onSocketDisconnect = this.onSocketDisconnect.bind(this);
+
+    this.socket.on("slaveCreate", this.onCommandSlaveCreate);
+    this.socket.on("slaveDelete", this.onCommandSlaveDelete);
+    this.socket.on("status", this.onCommandStatus);
+    this.socket.on("disconnect", this.onSocketDisconnect);
+};
+
+SlaveController.prototype.onCommandStatus = function () {
+    this.socket.emit("status", this.testServer.getStatus());
+};
+
+SlaveController.prototype.onCommandSlaveCreate = function (data) {
+    var slaveId = createSlaveId();
+    var slaveInfo = this.slavesInfo[slaveId] = {
+        slaveId: slaveId,
+        slave: null
+    };
+    slaveInfo.onSlaveConnect = this.onSlaveConnect.bind(this, slaveInfo);
+    slaveInfo.onSlaveDisconnect = this.onSlaveDisconnect.bind(this, slaveInfo);
+    slaveInfo.onSlaveIdle = this.onSlaveIdle.bind(this, slaveInfo);
+    slaveInfo.onSlaveBusy = this.onSlaveBusy.bind(this, slaveInfo);
+    this.testServer.on("slave-added-" + slaveId, slaveInfo.onSlaveConnect);
+    this.socket.emit("slaveCreated", slaveId);
+};
+
+var removeSlave = function (slaveInfo) {
+    var slave = slaveInfo.slave;
+    if (slave) {
+        slaveInfo.slave = null;
+        slave.removeListener("disconnect", slaveInfo.onSlaveDisconnect);
+        slave.removeListener("idle", slaveInfo.onSlaveIdle);
+        slave.removeListener("busy", slaveInfo.onSlaveBusy);
+        slave.disconnect(); // makes sure the slave is disconnected
+    }
+};
+
+SlaveController.prototype.onCommandSlaveDelete = function (slaveId) {
+    if (!this.slavesInfo.hasOwnProperty(slaveId)) {
+        return;
+    }
+    var slaveInfo = this.slavesInfo[slaveId];
+    delete this.slavesInfo[slaveId];
+    removeSlave(slaveInfo);
+    this.testServer.removeListener("slave-added-" + slaveId, slaveInfo.onSlaveConnect);
+    if (this.socket) {
+        this.socket.emit("slaveDeleted", slaveId);
+    }
+};
+
+SlaveController.prototype.onSlaveConnect = function (slaveInfo, slave) {
+    removeSlave(slaveInfo);
+    slaveInfo.slave = slave;
+    slave.on("disconnect", slaveInfo.onSlaveDisconnect);
+    slave.on("busy", slaveInfo.onSlaveBusy);
+    slave.on("idle", slaveInfo.onSlaveIdle);
+    this.socket.emit("slaveConnected", {
+        id: slaveInfo.slaveId,
+        address: slave.address,
+        port: slave.port,
+        displayName: slave.displayName,
+        userAgent: slave.userAgent
+    });
+};
+
+SlaveController.prototype.onSlaveDisconnect = function (slaveInfo) {
+    removeSlave(slaveInfo);
+    if (this.socket) {
+        this.socket.emit("slaveDisconnected", slaveInfo.slaveId);
+    }
+};
+
+SlaveController.prototype.onSlaveIdle = function (slaveInfo) {
+    if (this.socket) {
+        this.socket.emit("slaveIdle", slaveInfo.slaveId);
+    }
+};
+
+SlaveController.prototype.onSlaveBusy = function (slaveInfo) {
+    if (this.socket) {
+        this.socket.emit("slaveBusy", slaveInfo.slaveId);
+    }
+};
+
+SlaveController.prototype.onSocketDisconnect = function () {
+    this.socket = null;
+    var slavesInfo = this.slavesInfo;
+    for (var slaveId in slavesInfo) {
+        this.onCommandSlaveDelete(slaveId);
+    }
+    this.slavesInfo = null;
+};

--- a/lib/test-server/slave-server.js
+++ b/lib/test-server/slave-server.js
@@ -98,6 +98,7 @@ var feedEventWithTaskData = function (event, task) {
 };
 
 var Slave = function (socket, data, config) {
+    this.id = data.id;
     this.config = config;
     this.socket = socket;
     this.userAgent = data.userAgent;
@@ -110,6 +111,7 @@ var Slave = function (socket, data, config) {
     this.currentCampaign = null;
     this.paused = !! data.paused;
     this.taskTimeoutId = null;
+    this.idle = false;
     dns.reverse(this.address, this.onReceiveAddressName.bind(this));
     socket.on('disconnect', wrapInTryCatch(this, this.onSocketDisconnected));
     socket.on('test-update', wrapInTryCatch(this, this.onTestUpdate));
@@ -121,7 +123,8 @@ util.inherits(Slave, events.EventEmitter);
 
 Slave.prototype.toString = function () {
     var os = this.browserInfo.os.displayName;
-    return (this.addressName || this.address) + ":" + this.port + " (" + this.displayName + "; " + os + ")";
+    var id = this.id ? " " + this.id : "";
+    return (this.addressName || this.address) + ":" + this.port + id + " (" + this.displayName + "; " + os + ")";
 };
 
 Slave.prototype.onReceiveAddressName = function (err, names) {
@@ -134,6 +137,10 @@ Slave.prototype.assignTask = function (campaign, task) {
     this.currentTask = task;
     this.currentCampaign = campaign;
     this.currentTaskRestartPlanned = false;
+    if (this.idle) {
+        this.idle = false;
+        this.emit('busy');
+    }
     this.emit('unavailable');
     task.slave = this;
     var test = task.test;
@@ -177,7 +184,9 @@ Slave.prototype.onPauseChanged = function (paused) {
     if (this.paused !== paused) {
         this.paused = paused;
         if (!this.currentTask) {
-            this.emit(paused ? 'unavailable' : 'available');
+            if (!this.emitAvailable()) {
+                this.emit('unavailable');
+            }
         }
     }
 };
@@ -206,9 +215,16 @@ Slave.prototype.isAvailable = function () {
 };
 
 Slave.prototype.emitAvailable = function () {
-    if (this.isAvailable()) {
+    var res = this.isAvailable();
+    if (res) {
         this.emit('available');
+        if (this.isAvailable() && !this.idle) {
+            // still no task after saying it is available
+            this.idle = true;
+            this.emit('idle');
+        }
     }
+    return res;
 };
 
 Slave.prototype.getStatus = function () {

--- a/lib/test-server/test-server.js
+++ b/lib/test-server/test-server.js
@@ -15,6 +15,8 @@
 
 var url = require('url');
 var path = require('path');
+var util = require("util");
+var events = require("events");
 
 var connect = require('connect');
 var SocketIO = require('socket.io');
@@ -25,6 +27,7 @@ var attesterResultsUI = require('attester-results-ui');
 var http = require('./http-server.js');
 var Slave = require('./slave-server.js');
 var Viewer = require('./viewer-server.js');
+var SlaveController = require('./slave-controller.js');
 var Logger = require('../logging/logger.js');
 
 // middlewares
@@ -48,6 +51,11 @@ var clientTypes = {
     "viewer": function (socket, data) {
         // creates a new Viewer, which will register to campaign results
         new Viewer(socket, data, this);
+    },
+    "slaveController": function (socket, data) {
+        // creates a new slave controller, which will be notified when its slaves
+        // are connected, disconnected, and idle
+        new SlaveController(socket, data, this);
     }
 };
 
@@ -57,6 +65,10 @@ var socketConnection = function (socket) {
         var fn = clientTypes[data.type];
         if (fn) {
             fn.call(testServer, socket, data);
+        } else {
+            // unknown hello message: close the connection so that the remote
+            // program knows it is not supported
+            socket.close();
         }
     });
 };
@@ -225,6 +237,8 @@ var TestServer = function (config, logger) {
     this.frozen = config.frozen; // if frozen, then don't assign tasks
 };
 
+util.inherits(TestServer, events.EventEmitter);
+
 var serverURLPathnames = {
     'slave': '/__attester__/slave.html',
     'home': '/'
@@ -260,6 +274,7 @@ TestServer.prototype.getStatus = function () {
                 displayName: slave.displayName,
                 userAgent: slave.userAgent,
                 paused: slave.paused,
+                idle: slave.idle,
                 currentCampaign: slave.currentCampaign ? slave.currentCampaign.id : null,
                 currentTask: slave.currentTask ? slave.currentTask.test.name : null
             };
@@ -281,6 +296,7 @@ TestServer.prototype.getStatus = function () {
         })
     };
 };
+
 TestServer.prototype.close = function (callback) {
     var slaves = this.slaves;
     var slaveDisposeBack = _.after(slaves.length, function () {
@@ -300,13 +316,19 @@ TestServer.prototype.close = function (callback) {
 TestServer.prototype.addSlave = function (slave) {
     this.logger.logInfo("New slave connected: " + slave.toString());
     this.slaves.push(slave);
-    if (slave.isAvailable()) {
-        this.availableSlaves.push(slave);
-    }
     slave.once('disconnect', slaveDisconnected.bind(this, slave));
     slave.on('available', slaveAvailable.bind(this, slave));
     slave.on('unavailable', slaveUnavailable.bind(this, slave));
-    this.assignTasks();
+    if (slave.id) {
+        var listeners = this.emit('slave-added-' + slave.id, slave);
+        if (!listeners) {
+            // disconnects any slave which has an unregistered id
+            this.logger.logInfo("Id " + slave.id + " is not registered, slave will be disconnected.");
+            slave.disconnect();
+            return;
+        }
+    }
+    slave.emitAvailable(); // this will trigger assignTasks if the slave is available
 };
 
 TestServer.prototype.addCampaign = function (campaign) {


### PR DESCRIPTION
A slave controller can connect to attester through socket.io, then it can request slave ids that can be included in the url of the slaves so that the slave controller can be notified when its slaves are connected, disconnected and idle.

This pull request is a first step to be able to implement [attester-launcher](https://github.com/attester/attester-launcher).