### PR TITLE
Inclusion of PhantomJS in dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,11 +204,9 @@ Template options can be used both in `yaml` and `json` file and the environment 
 
 **Usual options:**
 
-`--phantomjs-path <path>` Path to the [PhantomJS](http://phantomjs.org/) executable (default: `phantomjs`).
+`--phantomjs-path <path>` Path to the [PhantomJS](http://phantomjs.org/) executable. It defaults to the path of phantomJS that is automatically installed locally.
 
-- *Important note: you have to install PhantomJS by yourself if you want to use it. Then, you must either
-pass `--phantomjs-path` argument, or add the folder containing `phantomjs.exe` to your system's `PATH`.
-Otherwise, you'll get runtime errors.*
+- *Important note: you can install PhantomJS by yourself. In that case you must pass `--phantomjs-path` argument. Otherwise, you'll get runtime errors.  However, we discourage you to do so because attester is not compatible with all versions of PhantomJS.*
 
 `--phantomjs-instances <number>` Number of instances of [PhantomJS](http://phantomjs.org/) to start (default: `0`).
 Additionally, a string `auto` can be passed to let the program use the optimal number of instances for best performance (max. 1 per CPU thread).

--- a/lib/attester/config.js
+++ b/lib/attester/config.js
@@ -36,7 +36,7 @@ exports.getDefaults = function () {
         'log-level': 3,
         'max-task-restarts': 5,
         'phantomjs-instances': process.env.npm_package_config_phantomjsInstances || 0,
-        'phantomjs-path': process.env.PHANTOMJS_PATH || 'phantomjs',
+        'phantomjs-path': process.env.PHANTOMJS_PATH || require('phantomjs').path,
         'port': 7777,
         'predictable-urls': false,
         'shutdown-on-campaign-end': true,

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
         "send": "0.9.3",
         "socket.io": "1.3.7",
         "ua-parser-js": "git+https://github.com/ariatemplates/ua-parser-js#latest",
-        "uglify-js": "2.5.0"
+        "uglify-js": "2.5.0",
+        "phantomjs": "1.9.8"
     },
     "devDependencies": {
         "ariatemplates": "1.6.6",


### PR DESCRIPTION
This commit adds `phantomjs` package to the dependencies so that there is no need to have it installed on the machine to use it.