### PR TITLE
Allowing to define flags in the URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ browsers:
   # You can mix all of that options, and have whitespace as you see fit.
   - 'Firefox >=25 on Windows 7 as Firefox/Windows'
   - 'Firefox >=25 on Ubuntu    as Firefox/Ubuntu'
+  # You can also add flags with the 'with' keyword to specify an environment which cannot be automatically detected.
+  # Flags have to be explicitly set in the URL when connecting a browser (e.g.: http://localhost:7777/__attester__/slave.html?flags=JAWS).
+  - 'IE 11 on Windows with JAWS as IE-JAWS'
+  - 'IE 11 on Windows with mySpecialFlag'
 ```
 
 Attester uses [ua-parser-js](https://github.com/faisalman/ua-parser-js) for browser and operating system detection and supports values as returned by ua-parser-js.

--- a/lib/test-campaign/browser.js
+++ b/lib/test-campaign/browser.js
@@ -18,11 +18,11 @@ var browserMatch = require('../util/browser-detection.js').browserMatch;
 /**
  * @see Browser.prototype.parseBrowserConfig
  * <li> Usage: </li>
- * <li> Input: 'Chrome >=30 on Desktop Windows as Chrome Canary 30' </li>
+ * <li> Input: 'Chrome >=30 on Desktop Windows with flags as Chrome Canary 30' </li>
  * <li> Match: [1] = 'Chrome', [2] = '>=30', [3] = 'Desktop Windows', [4] = 'Chrome Canary 30' </li>
  * Parts 2, 3, 4 are optional, will be undefined if not found.
  */
-var _browserCfgRegex = /^\s*(\S+)(?:\s+(\W*\d\S*))?(?:\s+on\s+(.*?))?(?:\s+as\s+(.*?))?\s*$/i;
+var _browserCfgRegex = /^\s*(\S+)(?:\s+(\W*\d\S*))?(?:\s+on\s+(.*?))?(?:\s+with\s+(.*?))?(?:\s+as\s+(.*?))?\s*$/i;
 
 var buildNameFromConfig = function (config) {
     if (config.displayAs) {
@@ -38,6 +38,9 @@ var buildNameFromConfig = function (config) {
     }
     if (config.os) {
         name += " (" + config.os + ")";
+    }
+    if (config.flags) {
+        name += " [" + config.flags + "]";
     }
     return name;
 };
@@ -112,7 +115,8 @@ Browser.parseBrowserConfig = function (cfgString) {
             browserName: match[1],
             browserVersion: match[2],
             os: match[3],
-            displayAs: match[4]
+            flags: match[4],
+            displayAs: match[5]
         };
     }
 };

--- a/lib/test-server/client/slave-client.js
+++ b/lib/test-server/client/slave-client.js
@@ -43,6 +43,13 @@
         }
         return null;
     })();
+    var flags = (function () {
+        var match = /(?:\?|\&)flags=([^&]+)/.exec(location.search);
+        if (match) {
+            return decodeURIComponent(match[1]);
+        }
+        return null;
+    })();
     var beginning = new Date();
 
     var log = window.location.search.indexOf("log=true") !== -1 ?
@@ -115,7 +122,8 @@
             id: slaveId,
             paused: paused,
             userAgent: window.navigator.userAgent,
-            documentMode: document.documentMode
+            documentMode: document.documentMode,
+            flags: flags
         });
     });
     socket.on('connect', socketStatusUpdater('connected'));

--- a/lib/util/browser-detection.js
+++ b/lib/util/browser-detection.js
@@ -57,7 +57,8 @@ exports.detectBrowser = function (data) {
         os: {
             displayName: osName + (os.version ? " " + os.version : ""),
             family: osName
-        }
+        },
+        flags: data.flags
     };
     return res;
 };
@@ -73,6 +74,10 @@ exports.browserMatch = function (config, browserInfo) {
     }
     if (match && config.os != null) {
         match = (config.os == browserInfo.os.family) || (config.os == browserInfo.os.displayName);
+    }
+    if (match) {
+        // flags must match exactly:
+        match = (config.flags || "") === (browserInfo.flags || "");
     }
     return match;
 };

--- a/spec/config/parseBrowserConfig.spec.js
+++ b/spec/config/parseBrowserConfig.spec.js
@@ -81,6 +81,41 @@ describe("parse browser config", function () {
                 displayAs: "Chrome Canary Linux"
             });
         });
+
+        it("should read name with version and flags", function () {
+            expect(Browser.parseBrowserConfig("IE 11 with JAWS")).toEqual({
+                browserName: "IE",
+                browserVersion: "11",
+                flags: "JAWS"
+            });
+        });
+
+        it("should read name with version, flags and alias", function () {
+            expect(Browser.parseBrowserConfig("IE 11 with JAWS as IEJAWS")).toEqual({
+                browserName: "IE",
+                browserVersion: "11",
+                flags: "JAWS",
+                displayAs: "IEJAWS"
+            });
+        });
+
+        it("should read name with flags and alias", function () {
+            expect(Browser.parseBrowserConfig("IE with JAWS as IEJAWS")).toEqual({
+                browserName: "IE",
+                flags: "JAWS",
+                displayAs: "IEJAWS"
+            });
+        });
+
+        it("should read name with version, os, flags and alias", function () {
+            expect(Browser.parseBrowserConfig("Chrome 30 on Desktop Linux with robot as Chrome Canary Linux")).toEqual({
+                browserName: "Chrome",
+                browserVersion: "30",
+                os: "Desktop Linux",
+                flags: "robot",
+                displayAs: "Chrome Canary Linux"
+            });
+        });
     });
 
     describe("whitespace and special chars tests", function () {

--- a/spec/util/browser-detection.spec.js
+++ b/spec/util/browser-detection.spec.js
@@ -18,11 +18,12 @@ var browserDetection = require('../../lib/util/browser-detection.js');
 
 describe('browser-detection', function () {
 
-    var getMatchingBrowsers = function (browserObjects, userAgent, documentMode) {
+    var getMatchingBrowsers = function (browserObjects, userAgent, documentMode, flags) {
         var res = [];
         var browserInfo = browserDetection.detectBrowser({
             userAgent: userAgent,
-            documentMode: documentMode
+            documentMode: documentMode,
+            flags: flags
         });
         browserObjects.forEach(function (browser) {
             var isMatch = browserDetection.browserMatch(browser.config, browserInfo);
@@ -51,6 +52,23 @@ describe('browser-detection', function () {
         expect(getMatchingBrowsers(browsers, "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0)", 9)).toEqual(["IE 9"]);
         expect(getMatchingBrowsers(browsers, "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0)", 10)).toEqual(["IE 10"]);
         expect(getMatchingBrowsers(browsers, "Mozilla/5.0 (Windows NT 6.1; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; rv:11.0) like Gecko")).toEqual(["IE 11"]);
+        expect(getMatchingBrowsers(browsers, "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10162")).toEqual(["Edge"]);
+        expect(getMatchingBrowsers(browsers, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/600.5.17 (KHTML, like Gecko) Version/8.0.5 Safari/600.5.17")).toEqual(["Safari"]);
+    });
+
+    it('should detect common browsers correctly with flags', function () {
+        var browserNames = ["Firefox 44", "Firefox 3", "Firefox 11", "Chrome 48", "IE 7", "IE 8", "IE 9", "IE 10", "IE 11", "IE 11 with JAWS", "Edge", "Safari"];
+        var browsers = createBrowserObjects(browserNames);
+        expect(getMatchingBrowsers(browsers, "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:44.0) Gecko/20100101 Firefox/44.0")).toEqual(["Firefox 44"]);
+        expect(getMatchingBrowsers(browsers, "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.2.15) Gecko/20110303 Firefox/3.6.15")).toEqual(["Firefox 3"]);
+        expect(getMatchingBrowsers(browsers, "Mozilla/5.0 (Windows NT 6.1; rv:11.0) Gecko/20100101 Firefox/11.0")).toEqual(["Firefox 11"]);
+        expect(getMatchingBrowsers(browsers, "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.109 Safari/537.36")).toEqual(["Chrome 48"]);
+        expect(getMatchingBrowsers(browsers, "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; SLCC1; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729)", 7)).toEqual(["IE 7"]);
+        expect(getMatchingBrowsers(browsers, "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0)", 8)).toEqual(["IE 8"]);
+        expect(getMatchingBrowsers(browsers, "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0)", 9)).toEqual(["IE 9"]);
+        expect(getMatchingBrowsers(browsers, "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0)", 10)).toEqual(["IE 10"]);
+        expect(getMatchingBrowsers(browsers, "Mozilla/5.0 (Windows NT 6.1; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; rv:11.0) like Gecko")).toEqual(["IE 11"]);
+        expect(getMatchingBrowsers(browsers, "Mozilla/5.0 (Windows NT 6.1; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; rv:11.0) like Gecko", undefined, "JAWS")).toEqual(["IE 11 [JAWS]"]);
         expect(getMatchingBrowsers(browsers, "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10162")).toEqual(["Edge"]);
         expect(getMatchingBrowsers(browsers, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/600.5.17 (KHTML, like Gecko) Version/8.0.5 Safari/600.5.17")).toEqual(["Safari"]);
     });


### PR DESCRIPTION
This commit adds support for a new `flags` parameter in the URL, so that it is possible to distinguish different environments which contain the same browser, and make sure the full campaign is executed on each environment.