### PR TITLE
Multiple campaigns fixes

### DIFF
--- a/lib/attester/launcher.js
+++ b/lib/attester/launcher.js
@@ -48,7 +48,8 @@ var childProcesses = require("../util/child-processes.js");
  * is always raised after server.attached and it always contains the slave URL
  */
 var urlInfo = null;
-var raiseOnAttached = false;
+var connectRaised = false;
+var expectedCampaigns = 0;
 
 // Raise the connect event
 
@@ -58,25 +59,26 @@ function raiseConnect() {
     });
 }
 
-function onServerAttached(event) {
-    urlInfo = event;
-    if (raiseOnAttached) {
+function checkAndRaiseConnect() {
+    if (!connectRaised && expectedCampaigns === 0) {
+        connectRaised = true;
         process.nextTick(raiseConnect);
     }
 }
 
-function onTasksList(event) {
-    if (!urlInfo) {
-        // The server is not attached yet
-        raiseOnAttached = true;
-    } else {
-        process.nextTick(raiseConnect);
-    }
+function onCampaignCreate() {
+    expectedCampaigns++;
+}
+
+function onServerAttached(event) {
+    urlInfo = event;
+    expectedCampaigns--;
+    checkAndRaiseConnect();
 }
 
 exports.__init__ = function () {
-    attester.event.once("attester.server.attached", onServerAttached);
-    attester.event.on("attester.campaign.tasksList", onTasksList);
+    attester.event.on("attester.server.attached", onServerAttached);
+    attester.event.on("campaign.create", onCampaignCreate);
     phantomLauncher.__init__();
     browserLauncher.__init__();
     robotBrowserLauncher.__init__();
@@ -85,14 +87,15 @@ exports.__init__ = function () {
 
 exports.__reset__ = function () {
     urlInfo = null;
-    raiseOnAttached = false;
+    connectRaised = false;
+    expectedCampaigns = 0;
 
     browserLauncher.__reset__();
     phantomLauncher.__reset__();
     robotBrowserLauncher.__reset__();
     attesterLauncher.__reset__();
     attester.event.off("attester.server.attached", onServerAttached);
-    attester.event.off("attester.campaign.tasksList", onTasksList);
+    attester.event.off("campaign.create", onCampaignCreate);
 
     var initialProcesses = childProcesses.number();
     if (initialProcesses > 0) {

--- a/lib/attester/reports.js
+++ b/lib/attester/reports.js
@@ -68,8 +68,8 @@ exports.writeReports = function (campaign, callback) {
         var stats = campaign.jsonReport.stats;
         var success = (ignoreErrors || stats.errors === 0) && (ignoreFailures || stats.failures === 0);
 
-        logSummary(stats);
-        logErrorsSummary(campaign.jsonReport.tasksErrors);
+        logSummary(campaign.logger, stats);
+        logErrorsSummary(campaign.logger, campaign.jsonReport.tasksErrors);
 
         attester.event.emit("reports.stats", stats);
 
@@ -77,50 +77,50 @@ exports.writeReports = function (campaign, callback) {
     });
 };
 
-function logSummary(stats) {
+function logSummary(logger, stats) {
     var msg = 'Tests run: ' + stats.testCases + ', ';
     var msgFailures = stats.failures ? ('Failures: ' + stats.failures + ', ').red.bold : 'Failures: 0, '.green;
     var msgErrors = stats.errors ? ('Errors: ' + stats.errors + ', ').red.bold : 'Errors: 0, '.green;
     var msgSkipped = stats.tasksIgnored ? ('Skipped: ' + stats.tasksIgnored).yellow.bold : 'Skipped: 0'.green;
-    attester.logger.logInfo(msg + msgFailures + msgErrors + msgSkipped);
+    logger.logInfo(msg + msgFailures + msgErrors + msgSkipped);
 }
 
-function logErrorsSummary(tasksErrors) {
-    attester.logger.logInfo("------------------------");
+function logErrorsSummary(logger, tasksErrors) {
+    logger.logInfo("------------------------");
     var browsersWithErrors = Object.keys(tasksErrors);
     if (browsersWithErrors.length === 0) {
-        printAsciiBanner("green");
-        attester.logger.logInfo("Everything okay!");
-        attester.logger.logInfo("------------------------");
+        printAsciiBanner(logger, "green");
+        logger.logInfo("Everything okay!");
+        logger.logInfo("------------------------");
         return;
     }
 
-    printAsciiBanner("red", "bold");
-    attester.logger.logInfo("Summary of errors and failures:".yellow);
+    printAsciiBanner(logger, "red", "bold");
+    logger.logInfo("Summary of errors and failures:".yellow);
     browsersWithErrors.forEach(function (browserName) {
         var errors = tasksErrors[browserName];
         errors.sort(taskComparator);
 
-        attester.logger.logInfo((browserName + " (" + errors.length + "):").yellow);
+        logger.logInfo((browserName + " (" + errors.length + "):").yellow);
         errors.forEach(function (item) {
-            attester.logger.logError(item.taskName + ": " + item.method);
-            attester.logger.logInfo(" " + item.errorMessage.white);
+            logger.logError(item.taskName + ": " + item.method);
+            logger.logInfo(" " + item.errorMessage.white);
         });
     });
-    attester.logger.logInfo("------------------------");
+    logger.logInfo("------------------------");
 }
 
-function printAsciiBanner(color, style) {
+function printAsciiBanner(logger, color, style) {
     color = color || "green";
     style = style || color;
-    attester.logger.logInfo("   _____                                                        " [style][color]);
-    attester.logger.logInfo("  / ____|                                                       " [style][color]);
-    attester.logger.logInfo(" | (___    _   _   _ __ ___    _ __ ___     __ _   _ __   _   _ " [style][color]);
-    attester.logger.logInfo("  \\___ \\  | | | | | '_ ` _ \\  | '_ ` _ \\   / _` | | '__| | | | |" [style][color]);
-    attester.logger.logInfo("  ____) | | |_| | | | | | | | | | | | | | | (_| | | |    | |_| |" [style][color]);
-    attester.logger.logInfo(" |_____/   \\__,_| |_| |_| |_| |_| |_| |_|  \\__,_| |_|     \\__, |" [style][color]);
-    attester.logger.logInfo("                                                           __/ |" [style][color]);
-    attester.logger.logInfo("                                                          |___/ " [style][color]);
+    logger.logInfo("   _____                                                        " [style][color]);
+    logger.logInfo("  / ____|                                                       " [style][color]);
+    logger.logInfo(" | (___    _   _   _ __ ___    _ __ ___     __ _   _ __   _   _ " [style][color]);
+    logger.logInfo("  \\___ \\  | | | | | '_ ` _ \\  | '_ ` _ \\   / _` | | '__| | | | |" [style][color]);
+    logger.logInfo("  ____) | | |_| | | | | | | | | | | | | | | (_| | | |    | |_| |" [style][color]);
+    logger.logInfo(" |_____/   \\__,_| |_| |_| |_| |_| |_| |_|  \\__,_| |_|     \\__, |" [style][color]);
+    logger.logInfo("                                                           __/ |" [style][color]);
+    logger.logInfo("                                                          |___/ " [style][color]);
 }
 
 // Create all global reports, generic for attester
@@ -149,7 +149,7 @@ function createCampaignReports(campaign) {
     campaign.on("result", jsonReport.addResult.bind(jsonReport));
     campaign.jsonReport = jsonReport;
 
-    var consoleReport = new ConsoleReport(attester.logger, campaign, config["slow-test-threshold"]);
+    var consoleReport = new ConsoleReport(campaign.logger, campaign, config["slow-test-threshold"]);
     campaign.on("result", consoleReport.addResult.bind(consoleReport));
 
     var logReports = campaign.config["test-reports"]["json-log-file"];

--- a/lib/test-campaign/test-campaign.js
+++ b/lib/test-campaign/test-campaign.js
@@ -45,8 +45,8 @@ var TestCampaign = function (config, parentLogger) {
     this.campaignNumber = config.campaignNumber;
     this.id = createCampaignId(this.startTime);
     this.baseURL = "/campaign" + (config.predictableUrls ? this.campaignNumber : this.id);
-    this.logger = new Logger('TestCampaign', this.id, parentLogger);
-    this.logger.logInfo("Initializing campaign...");
+    this.logger = new Logger('TestCampaign', this.campaignNumber, parentLogger);
+    this.logger.logInfo("Initializing campaign " + this.id + "...");
 
     var rootDirectory = config.rootDirectory || "";
     this.rootDirectory = rootDirectory;


### PR DESCRIPTION
This PR fixes the following issues when running multiple campaigns in parallel:
* `launcher.connect` was raised once for each campaign instead of once for all (which most likely resulted in more phantomjs instances than configured being started by attester, or attester-launcher being started multiple times)
* the logs did not clearly allow to distinguish between campaigns
