### PR TITLE
Adding taskExecutionId to check the link between a task and its updates

### DIFF
--- a/lib/test-server/client/slave-client.js
+++ b/lib/test-server/client/slave-client.js
@@ -18,8 +18,11 @@
     var window = this;
     var config = window.attesterConfig || {}; // a config object can be set by the PhantomJS script
     window.attesterConfig = null;
-    var attester = {};
-    window.attester = attester;
+    var AttesterAPI = function (taskExecutionId) {
+        this.__taskExecutionId = taskExecutionId || -1;
+        this.currentTask = {};
+    };
+    var attesterPrototype = AttesterAPI.prototype = {};
 
     var location = window.location;
     var document = window.document;
@@ -80,15 +83,15 @@
 
     var removeIframe = function () {
         if (iframe) {
-            attester.currentTask = null;
+            window.attester = null;
             iframeParent.removeChild(iframe);
             iframe = null;
         }
     };
 
-    var createIframe = function (src) {
+    var createIframe = function (src, taskExecutionId) {
         removeIframe();
-        attester.currentTask = {};
+        window.attester = new AttesterAPI(taskExecutionId);
         iframe = document.createElement("iframe");
         iframe.setAttribute("id", "iframe");
         iframe.setAttribute("src", src);
@@ -115,7 +118,7 @@
 
     socket.on('connect', function () {
         log("slave connected");
-        attester.connected = true;
+        attesterPrototype.connected = true;
         stop();
         socket.emit('hello', {
             type: 'slave',
@@ -130,7 +133,7 @@
 
     socket.on('disconnect', function () {
         log("slave disconnected");
-        attester.connected = false;
+        attesterPrototype.connected = false;
     });
     socket.on('disconnect', socketStatusUpdater('disconnected'));
     if (config.onDisconnect) {
@@ -150,7 +153,7 @@
         testInfo = "executing";
         updateStatus();
         log("<i>slave-execute</i> task <i>" + data.name + "</i>, " + data.stats.remainingTasks + " tasks left");
-        createIframe(baseUrl + data.url);
+        createIframe(baseUrl + data.url, data.taskExecutionId);
     });
     socket.on('slave-stop', stop);
     socket.on('disconnect', stop);
@@ -168,9 +171,17 @@
         return false;
     };
 
-    var sendTestUpdate = function (name, info) {
-        if (!currentTask) {
-            return;
+    var checkTaskExecutionId = function (scope, name) {
+        var res = currentTask && scope.__taskExecutionId === currentTask.taskExecutionId;
+        if (!res) {
+            log("<i>warning</i> ignoring call to attester." + name + " for a task that is not valid.");
+        }
+        return res;
+    };
+
+    var sendTestUpdate = function (scope, name, info) {
+        if (!checkTaskExecutionId(scope, name)) {
+            return false;
         }
         if (!info) {
             info = {};
@@ -197,25 +208,26 @@
         if (name === "error") {
             log("<i class='error'>error</i> message: <i>" + info.error.message + "</i>");
         }
-        socket.emit('test-update', info);
+        socket.emit('test-update', info, currentTask.taskExecutionId);
+        return true;
     };
 
-    attester.testStart = function (info) {
-        sendTestUpdate('testStarted', info);
+    attesterPrototype.testStart = function (info) {
+        sendTestUpdate(this, 'testStarted', info);
     };
-    attester.testEnd = function (info) {
-        sendTestUpdate('testFinished', info);
+    attesterPrototype.testEnd = function (info) {
+        sendTestUpdate(this, 'testFinished', info);
     };
-    attester.testError = function (info) {
-        sendTestUpdate('error', info);
+    attesterPrototype.testError = function (info) {
+        sendTestUpdate(this, 'error', info);
     };
-    attester.taskFinished = function () {
-        if (!currentTask) {
+    attesterPrototype.taskFinished = function () {
+        if (!checkTaskExecutionId(this, "taskFinished")) {
             return;
         }
-        socket.emit('task-finished');
+        socket.emit('task-finished', currentTask.taskExecutionId);
     };
-    attester.stackTrace = function (exception) {
+    attesterPrototype.stackTrace = function (exception) {
         // this function is re-defined in stacktrace.js
         return [];
     };
@@ -228,26 +240,24 @@
         xhr.send(data);
     };
 
-    attester.coverage = function (window) {
+    attesterPrototype.coverage = function (window) {
         var $$_l = window.$$_l;
         if ($$_l) {
-            sendTestUpdate('coverage'); // notify the server through socket.io that we are sending coverage (so that it
-            // will wait for it)
-            send('/__attester__/coverage/data/' + currentTask.campaignId + '/' + currentTask.taskId, JSON.stringify({
-                name: "",
-                lines: $$_l.lines,
-                runLines: $$_l.runLines,
-                code: $$_l.code,
-                allConditions: $$_l.allConditions,
-                conditions: $$_l.conditions,
-                allFunctions: $$_l.allFunctions,
-                runFunctions: $$_l.runFunctions
-            }));
+            // notify the server through socket.io that we are sending coverage (so that it will wait for it):
+            if (sendTestUpdate(this, 'coverage')) {
+                send('/__attester__/coverage/data/' + currentTask.campaignId + '/' + currentTask.taskId, JSON.stringify({
+                    name: "",
+                    lines: $$_l.lines,
+                    runLines: $$_l.runLines,
+                    code: $$_l.code,
+                    allConditions: $$_l.allConditions,
+                    conditions: $$_l.conditions,
+                    allFunctions: $$_l.allFunctions,
+                    runFunctions: $$_l.runFunctions
+                }));
+            }
         }
     };
-
-    // Used to store methods and properties specific to the running task
-    attester.currentTask = {};
 
     // Creating an empty iframe so that IE can replace its url without any harm
     // (when refreshing the page, IE tries to restore the previous URL of the iframe)

--- a/lib/test-server/slave-server.js
+++ b/lib/test-server/slave-server.js
@@ -18,6 +18,7 @@ var events = require("events");
 var dns = require("dns");
 
 var slaveCounter = 0;
+var taskExecutionCount = 0;
 
 var detectBrowser = require("../util/browser-detection.js").detectBrowser;
 
@@ -52,6 +53,7 @@ var campaignTaskFinished = function (scope) {
     var task = scope.currentTask;
     var campaign = scope.currentCampaign;
     var restart = scope.currentTaskRestartPlanned;
+    scope.taskExecutionId = null;
     scope.currentTask = null;
     scope.currentCampaign = null;
     scope.currentTaskRestartPlanned = false;
@@ -110,6 +112,7 @@ var Slave = function (socket, data, config) {
     this.address = socket.conn.remoteAddress;
     this.port = socket.request.connection.remotePort;
     this.addressName = null; // set by onReceiveAddressName
+    this.taskExecutionId = null;
     this.currentTask = null;
     this.currentCampaign = null;
     this.paused = !!data.paused;
@@ -156,6 +159,7 @@ Slave.prototype.findTask = function () {
 };
 
 Slave.prototype.assignTask = function (campaign, task) {
+    var taskExecutionId = this.taskExecutionId = ++taskExecutionCount;
     this.currentTask = task;
     this.currentCampaign = campaign;
     this.currentTaskRestartPlanned = false;
@@ -170,6 +174,7 @@ Slave.prototype.assignTask = function (campaign, task) {
         url: test.url,
         name: test.name,
         taskId: task.taskId,
+        taskExecutionId: taskExecutionId,
         campaignId: campaign.id,
         stats: {
             remainingTasks: campaign.remainingTasks,
@@ -191,12 +196,15 @@ Slave.prototype.assignTask = function (campaign, task) {
     this.taskTimeoutId = setTimeout(this.taskTimeout.bind(this), this.config.taskTimeout);
 };
 
-Slave.prototype.onTestUpdate = function (event) {
+Slave.prototype.onTestUpdate = function (event, taskExecutionId) {
     var eventName = event.event;
     if (eventName == "error" && this.config.taskRestartOnFailure) {
         this.currentTaskRestartPlanned = true;
     }
     if (allowedTestUpdateEvents.hasOwnProperty(eventName)) {
+        if (!this.checkTaskExecutionId(taskExecutionId)) {
+            return;
+        }
         feedEventWithTaskData(event, this.currentTask);
         this.currentCampaign.addResult(event);
     }
@@ -223,8 +231,15 @@ Slave.prototype.onSocketDisconnected = function () {
     }
 };
 
-Slave.prototype.onTaskFinished = function () {
+Slave.prototype.onTaskFinished = function (taskExecutionId) {
+    if (!this.checkTaskExecutionId(taskExecutionId)) {
+        return;
+    }
     campaignTaskFinished(this);
+};
+
+Slave.prototype.checkTaskExecutionId = function (taskExecutionId) {
+    return taskExecutionId === this.taskExecutionId;
 };
 
 Slave.prototype.disconnect = function () {


### PR DESCRIPTION
In some cases, a task can impact the following one by reporting updates after the `taskFinished` event.
This commit adds an id which is different for each task execution to avoid this kind of issues.