### PR TITLE
Adding logging features

### DIFF
--- a/lib/test-server/client/iframe.js
+++ b/lib/test-server/client/iframe.js
@@ -44,9 +44,12 @@
                 return [];
             },
             coverage: function () {},
+            installConsole: function () {},
             currentTask: {}
         };
     }
+
+    attester.installConsole(window);
 
     // This should be implemented by test-types
     attester.currentTask.start = function () {};

--- a/lib/test-server/client/slave-client.js
+++ b/lib/test-server/client/slave-client.js
@@ -67,6 +67,19 @@
             logs.firstChild.scrollIntoView(false);
         } : function () {};
 
+    var reportLogToServer = function (level, args, taskExecutionId) {
+        var time = new Date().getTime();
+        var msg = [];
+        for (var i = 0, l = args.length; i < l; i++) {
+            msg.push(String(args[i]));
+        }
+        socket.emit("log", {
+            time: time,
+            level: level,
+            message: msg.join(" ")
+        }, taskExecutionId);
+    };
+
     var updateStatus = function () {
         statusBar.innerHTML = socketStatus + " - " + testStatus;
         pauseResume.innerHTML = paused ? "Resume" : "Pause";
@@ -200,7 +213,7 @@
             var previousTestStart = pendingTestStarts[info.testId];
             if (!previousTestStart) {
                 log("<i>warning</i> this <i>testFinished</i> is ignored as it has no previous <i>testStarted</i>");
-                return;
+                return false;
             }
             pendingTestStarts[info.testId] = false;
             info.duration = info.time - previousTestStart.time;
@@ -230,6 +243,30 @@
     attesterPrototype.stackTrace = function (exception) {
         // this function is re-defined in stacktrace.js
         return [];
+    };
+
+    var replaceConsoleFunction = function (console, name, scope) {
+        var oldFunction = console[name] || function () {};
+        console[name] = function () {
+            var res = oldFunction.apply(this, arguments);
+            var taskExecutionId = scope.__taskExecutionId;
+            if (!currentTask || currentTask.taskExecutionId !== taskExecutionId) {
+                taskExecutionId = -1;
+            }
+            reportLogToServer(name, arguments, taskExecutionId);
+            return res;
+        };
+    };
+
+    attesterPrototype.installConsole = function (window) {
+        var console = window.console;
+        if (!console) {
+            console = window.console = {};
+        }
+        replaceConsoleFunction(console, "log", this);
+        replaceConsoleFunction(console, "info", this);
+        replaceConsoleFunction(console, "warn", this);
+        replaceConsoleFunction(console, "error", this);
     };
 
     // To send coverage, using a POST request rather than using socket.io is better for performance reasons

--- a/lib/test-server/client/slave-client.js
+++ b/lib/test-server/client/slave-client.js
@@ -187,7 +187,9 @@
     var checkTaskExecutionId = function (scope, name) {
         var res = currentTask && scope.__taskExecutionId === currentTask.taskExecutionId;
         if (!res) {
-            log("<i>warning</i> ignoring call to attester." + name + " for a task that is not valid.");
+            var message = "ignoring call to attester." + name + " for a task that is not (or no longer) valid.";
+            reportLogToServer("warn", [message]);
+            log("<i>warning</i> " + message);
         }
         return res;
     };

--- a/lib/test-server/slave-server.js
+++ b/lib/test-server/slave-server.js
@@ -201,12 +201,12 @@ Slave.prototype.assignTask = function (campaign, task) {
 
 Slave.prototype.onTestUpdate = function (event, taskExecutionId) {
     var eventName = event.event;
-    if (eventName == "error" && this.config.taskRestartOnFailure) {
-        this.currentTaskRestartPlanned = true;
+    if (!this.checkTaskExecutionId(taskExecutionId, eventName)) {
+        return;
     }
     if (allowedTestUpdateEvents.hasOwnProperty(eventName)) {
-        if (!this.checkTaskExecutionId(taskExecutionId)) {
-            return;
+        if (eventName == "error" && this.config.taskRestartOnFailure) {
+            this.currentTaskRestartPlanned = true;
         }
         feedEventWithTaskData(event, this.currentTask);
         this.currentCampaign.addResult(event);
@@ -257,14 +257,18 @@ Slave.prototype.onClientLog = function (event, taskExecutionId) {
 };
 
 Slave.prototype.onTaskFinished = function (taskExecutionId) {
-    if (!this.checkTaskExecutionId(taskExecutionId)) {
+    if (!this.checkTaskExecutionId(taskExecutionId, "taskFinished")) {
         return;
     }
     campaignTaskFinished(this);
 };
 
-Slave.prototype.checkTaskExecutionId = function (taskExecutionId) {
-    return taskExecutionId === this.taskExecutionId;
+Slave.prototype.checkTaskExecutionId = function (taskExecutionId, eventName) {
+    var res = taskExecutionId === this.taskExecutionId;
+    if (!res) {
+        this.logger.logWarn("Ignoring %s event from a previous task, not filtered by the client.", [eventName]);
+    }
+    return res;
 };
 
 Slave.prototype.disconnect = function () {

--- a/lib/test-server/slave-server.js
+++ b/lib/test-server/slave-server.js
@@ -16,6 +16,7 @@
 var util = require("util");
 var events = require("events");
 var dns = require("dns");
+var Logger = require('../logging/logger.js');
 
 var slaveCounter = 0;
 var taskExecutionCount = 0;
@@ -101,9 +102,10 @@ var feedEventWithTaskData = function (event, task) {
     return event;
 };
 
-var Slave = function (socket, data, config) {
+var Slave = function (socket, data, config, logger) {
     this.id = data.id;
     this.slaveNumber = ++slaveCounter;
+    this.logger = new Logger("Slave", this.slaveNumber, logger);
     this.config = config;
     this.socket = socket;
     this.userAgent = data.userAgent;
@@ -129,6 +131,7 @@ var Slave = function (socket, data, config) {
     socket.on('test-update', wrapInTryCatch(this, this.onTestUpdate));
     socket.on('task-finished', wrapInTryCatch(this, this.onTaskFinished));
     socket.on('pause-changed', wrapInTryCatch(this, this.onPauseChanged));
+    socket.on('log', wrapInTryCatch(this, this.onClientLog));
 };
 
 util.inherits(Slave, events.EventEmitter);
@@ -228,6 +231,28 @@ Slave.prototype.onSocketDisconnected = function () {
         this.currentTaskRestartPlanned = true;
         emitTaskError(this, "Browser was disconnected: " + this.toString());
         this.emit('disconnect');
+        this.logger.dispose();
+    }
+};
+
+var clientLogLevels = {
+    "log": Logger.LEVEL_INFO,
+    "info": Logger.LEVEL_INFO,
+    "warn": Logger.LEVEL_WARN,
+    "error": Logger.LEVEL_ERROR
+};
+
+Slave.prototype.onClientLog = function (event, taskExecutionId) {
+    var eventLevel = event.level;
+    var loggerLevel = +clientLogLevels[eventLevel];
+    if (!isNaN(loggerLevel)) {
+        this.logger.log(loggerLevel, "[console.%s] %s", [eventLevel, event.message]);
+        var currentTask = this.currentTask;
+        if (currentTask && taskExecutionId === this.taskExecutionId) {
+            feedEventWithTaskData(event, currentTask);
+            event.event = "log";
+            this.currentCampaign.addResult(event);
+        }
     }
 };
 

--- a/lib/test-server/test-server.js
+++ b/lib/test-server/test-server.js
@@ -50,7 +50,7 @@ var arrayRemove = function (array, item) {
 
 var clientTypes = {
     "slave": function (socket, data) {
-        var newSlave = new Slave(socket, data, this.config);
+        var newSlave = new Slave(socket, data, this.config, this.logger);
         this.addSlave(newSlave);
     },
     "viewer": function (socket, data) {


### PR DESCRIPTION
This pull request adds logging features to attester to help debugging.

When using one of the console methods (log, info, warn or error) from a test in any browser, the log is now reported to the attester server and displayed on its console for the corresponding slave.
If the console method is called from the currently running task, the corresponding log events are also included in the campaign logs (to be displayed in attester-results-ui).

This PR also makes sure all issues with taskExecutionId are reported on the console of the attester server.
It also fixes a case in which a task could be re-executed even when it did not fail.