### PR TITLE
Updating ua-parser-js (0.7.10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "serve-favicon": "2.3.0",
         "serve-static": "1.11.1",
         "socket.io": "1.4.8",
-        "ua-parser-js": "git+https://github.com/ariatemplates/ua-parser-js#latest",
+        "ua-parser-js": "0.7.10",
         "uglify-js": "2.7.3"
     },
     "devDependencies": {


### PR DESCRIPTION
It is no longer useful to rely on our fork of ua-parser-js, now that our changes have been integrated:
 - https://github.com/faisalman/ua-parser-js/pull/122
 - https://github.com/faisalman/ua-parser-js/pull/139