### PR TITLE
Fix instance number calculation if limited RAM

### DIFF
--- a/lib/util/optimize-parallel.js
+++ b/lib/util/optimize-parallel.js
@@ -49,8 +49,11 @@ var optimizeNumberOfParallelInstances = function (cfg, logger) {
     // further limit max instances by available RAM
     var availableRamMB = os.freemem() / 1048576;
     var memPerInstanceMB = parseInt(cfg.memoryPerInstance, 10) || 1;
-    var maxInstancesWithinRam = availableRamMB / memPerInstanceMB;
+    var maxInstancesWithinRam = Math.floor(availableRamMB / memPerInstanceMB);
     maxInstances = Math.min(maxInstances, maxInstancesWithinRam);
+    
+    // guarantee at least one instance is running
+    maxInstances = Math.max(maxInstances, 1);
 
     if (maxInstances < initialMaxInstances) {
         logger.logWarn("Limiting the number of PhantomJS instances from " + initialMaxInstances + " to " + maxInstances);


### PR DESCRIPTION
Hi,

Fix for this issue:
https://github.com/attester/attester/issues/150

Expected behaviour:
- Number of instance should be an int
- If not enough RAM, run with 1 instance
