### PR TITLE
Switching to sockjs instead of socket.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: node_js
 node_js:
- - 4.2
- - 6
+ - "8.2"
+ - "6.9.1"
 sudo: false
 cache:
  directories:
   - node_modules
 before_install:
- - npm install -g npm@3
  - npm --version
  - phantomjs --version
- - npm install -g geckodriver@1.4
+ - npm install -g geckodriver@1.8
 before_script:
  - chmod 777 ./travis_sauce_connect.sh
  - ./travis_sauce_connect.sh
@@ -23,4 +22,4 @@ env:
   - SAUCE_USERNAME=ariatemplates
   - SAUCE_ACCESS_KEY=620e638e-90d2-48e1-b66c-f9505dcb888b
 addons:
- firefox: "49.0"
+ firefox: "54.0"

--- a/lib/launchers/phantom-launcher.js
+++ b/lib/launchers/phantom-launcher.js
@@ -40,6 +40,7 @@ var cfg = {
     phantomInstances: 0
 };
 var state = {
+    resetCalled: false,
     retries: [],
     // stores how many times each instance was rebooted
     erroredPhantomInstances: 0
@@ -50,9 +51,11 @@ var state = {
 // They don't rely on global `cfg` and `state` but on parameters for for the same reason.
 module.exports = {
     __init__: function () {
+        state.resetCalled = false;
         attester.event.on("launcher.connect", onLauncherConnect);
     },
     __reset__: function () {
+        state.resetCalled = true;
         attester.event.off("launcher.connect", onLauncherConnect);
     },
     /**
@@ -106,7 +109,7 @@ module.exports = {
         // launching the command are both handled in 'exit' callback
         return function (code, signal) {
             // See http://tldp.org/LDP/abs/html/exitcodes.html and http://stackoverflow.com/a/1535733/
-            if (code === 0 || signal == "SIGTERM") {
+            if (code === 0 || signal == "SIGTERM" || state.resetCalled) {
                 return;
             }
 

--- a/lib/test-server/client/slave-client.js
+++ b/lib/test-server/client/slave-client.js
@@ -1,4 +1,4 @@
-/* global io */
+/* global SockJS */
 /*
  * Copyright 2012 Amadeus s.a.s.
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -73,11 +73,15 @@
         for (var i = 0, l = args.length; i < l; i++) {
             msg.push(String(args[i]));
         }
-        socket.emit("log", {
-            time: time,
-            level: level,
-            message: msg.join(" ")
-        }, taskExecutionId);
+        socket.send(JSON.stringify({
+            type: 'log',
+            taskExecutionId: taskExecutionId,
+            event: {
+                time: time,
+                level: level,
+                message: msg.join(" ")
+            }
+        }));
     };
 
     var updateStatus = function () {
@@ -86,12 +90,10 @@
         statusInfo.innerHTML = "<span id='_info_" + testInfo + "'></span>";
     };
 
-    var socketStatusUpdater = function (status, info) {
-        return function (param) {
-            socketStatus = param ? status.replace('$', param) : status;
-            testInfo = info || status;
-            updateStatus();
-        };
+    var socketStatusUpdate = function (status, info) {
+        socketStatus = status;
+        testInfo = info || status;
+        updateStatus();
     };
 
     var removeIframe = function () {
@@ -123,64 +125,85 @@
     };
 
     log("creating a socket");
-    var socket = io(location.protocol + '//' + location.host, {
-        reconnection: true,
-        reconnectionDelay: 500,
-        reconnectionDelayMax: 5000
-    });
 
-    socket.on('connect', function () {
+    var socket;
+
+    var onSocketOpen = function () {
         log("slave connected");
+        socketStatusUpdate('connected');
         attesterPrototype.connected = true;
         stop();
-        socket.emit('hello', {
+        socket.send(JSON.stringify({
             type: 'slave',
             id: slaveId,
             paused: paused,
             userAgent: window.navigator.userAgent,
             documentMode: document.documentMode,
             flags: flags
-        });
-    });
-    socket.on('connect', socketStatusUpdater('connected'));
+        }));
+    };
 
-    socket.on('disconnect', function () {
+    var onSocketClose = function () {
         log("slave disconnected");
+        socketStatusUpdate('disconnected');
         attesterPrototype.connected = false;
-    });
-    socket.on('disconnect', socketStatusUpdater('disconnected'));
-    if (config.onDisconnect) {
-        socket.on('disconnect', config.onDisconnect);
-    }
-    socket.on('reconnecting', socketStatusUpdater('reconnecting in $ ms...', 'disconnected'));
-    socket.on('reconnect', socketStatusUpdater('re-connected', 'connected'));
-    socket.on('reconnect_failed', socketStatusUpdater('failed to reconnect', 'disconnected'));
-    socket.on('slave-execute', function (data) {
-        currentTask = data;
-        pendingTestStarts = {};
-        removeIframe();
-        testStatus = "executing " + data.name + " remaining " + data.stats.remainingTasks + " tasks in this campaign";
-        if (data.stats.browserRemainingTasks != data.stats.remainingTasks) {
-            testStatus += ", including " + data.stats.browserRemainingTasks + " tasks for this browser";
+        stop();
+        if (config.onDisconnect) {
+            config.onDisconnect();
         }
-        testInfo = "executing";
-        updateStatus();
-        log("<i>slave-execute</i> task <i>" + data.name + "</i>, " + data.stats.remainingTasks + " tasks left");
-        createIframe(baseUrl + data.url, data.taskExecutionId);
-    });
-    socket.on('slave-stop', stop);
-    socket.on('disconnect', stop);
-    if (config.onDispose) {
-        socket.on('dispose', function () {
-            config.onDispose();
-        });
-    }
+        setTimeout(createConnection, 1000);
+    };
+
+    var messages = {
+        slaveExecute: function (data) {
+            currentTask = data;
+            pendingTestStarts = {};
+            removeIframe();
+            testStatus = "executing " + data.name + " remaining " + data.stats.remainingTasks + " tasks in this campaign";
+            if (data.stats.browserRemainingTasks != data.stats.remainingTasks) {
+                testStatus += ", including " + data.stats.browserRemainingTasks + " tasks for this browser";
+            }
+            testInfo = "executing";
+            updateStatus();
+            log("<i>slave-execute</i> task <i>" + data.name + "</i>, " + data.stats.remainingTasks + " tasks left");
+            createIframe(baseUrl + data.url, data.taskExecutionId);
+        },
+        slaveStop: stop,
+        dispose: function () {
+            if (config.onDispose) {
+                config.onDispose();
+            }
+        }
+    };
+
+    var onSocketMessage = function (message) {
+        var data = JSON.parse(message.data);
+        var type = data.type;
+        if (messages.hasOwnProperty(type)) {
+            messages[type](data);
+        }
+    };
+
+    var createConnection = function () {
+        socketStatusUpdate('connecting');
+        socket = new SockJS(location.protocol + '//' + location.host + '/sockjs');
+        socket.onopen = onSocketOpen;
+        socket.onclose = onSocketClose;
+        socket.onmessage = onSocketMessage;
+    };
+
+    createConnection();
 
     pauseResume.onclick = function () {
         log("toggle pause status");
         paused = !paused;
         updateStatus();
-        socket.emit('pause-changed', paused);
+        if (attesterPrototype.connected) {
+            socket.send(JSON.stringify({
+                type: 'pauseChanged',
+                paused: paused
+            }));
+        }
         return false;
     };
 
@@ -223,7 +246,11 @@
         if (name === "error") {
             log("<i class='error'>error</i> message: <i>" + info.error.message + "</i>");
         }
-        socket.emit('test-update', info, currentTask.taskExecutionId);
+        socket.send(JSON.stringify({
+            type: 'testUpdate',
+            event: info,
+            taskExecutionId: currentTask.taskExecutionId
+        }));
         return true;
     };
 
@@ -240,7 +267,10 @@
         if (!checkTaskExecutionId(this, "taskFinished")) {
             return;
         }
-        socket.emit('task-finished', currentTask.taskExecutionId);
+        socket.send(JSON.stringify({
+            type: 'taskFinished',
+            taskExecutionId: currentTask.taskExecutionId
+        }));
     };
     attesterPrototype.stackTrace = function (exception) {
         // this function is re-defined in stacktrace.js
@@ -251,8 +281,11 @@
     var replaceConsoleFunction = function (console, name, scope) {
         var oldFunction = config.localConsole === false ? emptyFunction : console[name] || emptyFunction;
         console[name] = function () {
-            // IE < 9 compatible: http://stackoverflow.com/questions/5538972/console-log-apply-not-working-in-ie9#comment8444540_5539378
-            var res = Function.prototype.apply.call(oldFunction, this, arguments);
+            var res;
+            try {
+                // IE < 9 compatible: http://stackoverflow.com/questions/5538972/console-log-apply-not-working-in-ie9#comment8444540_5539378
+                res = Function.prototype.apply.call(oldFunction, this, arguments);
+            } catch (e) {}
             var taskExecutionId = scope.__taskExecutionId;
             if (!currentTask || currentTask.taskExecutionId !== taskExecutionId) {
                 taskExecutionId = -1;
@@ -274,7 +307,7 @@
         replaceConsoleFunction(console, "error", this);
     };
 
-    // To send coverage, using a POST request rather than using socket.io is better for performance reasons
+    // To send coverage, using a POST request rather than using sockjs is better for performance reasons
     var send = function (url, data) {
         var xhr = (window.ActiveXObject) ? new window.ActiveXObject("Microsoft.XMLHTTP") : new window.XMLHttpRequest();
         xhr.open('POST', url);
@@ -285,7 +318,7 @@
     attesterPrototype.coverage = function (window) {
         var $$_l = window.$$_l;
         if ($$_l) {
-            // notify the server through socket.io that we are sending coverage (so that it will wait for it):
+            // notify the server through sockjs that we are sending coverage (so that it will wait for it):
             if (sendTestUpdate(this, 'coverage')) {
                 send('/__attester__/coverage/data/' + currentTask.campaignId + '/' + currentTask.taskId, JSON.stringify({
                     name: "",

--- a/lib/test-server/client/slave.html
+++ b/lib/test-server/client/slave.html
@@ -21,8 +21,7 @@
 		<p>To enable logs add <i>?log=true</i> in the URL.</p>
 	</div>
 	<script src="json3/json3.min.js"></script>
-	<script src="js-polyfills/typedarray.js"></script>
-	<script src="/socket.io/socket.io.js"></script>
+	<script src="sockjs/sockjs.js"></script>
 	<% _(query.plugin || []).castArray().forEach(function (plugin) {%><script src="<%= encodeURI(plugin) %>"></script><%}); %>
 	<script src="slave-client.js"></script>
 	<script src="stacktrace.js"></script>

--- a/lib/test-server/slave-controller.js
+++ b/lib/test-server/slave-controller.js
@@ -25,22 +25,31 @@ var SlaveController = module.exports = function (socket, data, testServer) {
     this.socket = socket;
     this.testServer = testServer;
     this.slavesInfo = {};
-    this.onCommandSlaveCreate = this.onCommandSlaveCreate.bind(this);
-    this.onCommandSlaveDelete = this.onCommandSlaveDelete.bind(this);
-    this.onCommandStatus = this.onCommandStatus.bind(this);
+    this.onSocketMessage = this.onSocketMessage.bind(this);
     this.onSocketDisconnect = this.onSocketDisconnect.bind(this);
-
-    this.socket.on("slaveCreate", this.onCommandSlaveCreate);
-    this.socket.on("slaveDelete", this.onCommandSlaveDelete);
-    this.socket.on("status", this.onCommandStatus);
-    this.socket.on("disconnect", this.onSocketDisconnect);
+    socket.on('data', this.onSocketMessage);
+    socket.on('close', this.onSocketDisconnect);
 };
 
-SlaveController.prototype.onCommandStatus = function () {
-    this.socket.emit("status", this.testServer.getStatus());
+SlaveController.prototype.onSocketMessage = function (message) {
+    try {
+        var data = JSON.parse(message);
+        var type = data.type;
+        var handler = this["onSocketMessage_" + type];
+        if (handler) {
+            handler.call(this, data);
+        }
+    } catch (e) {}
 };
 
-SlaveController.prototype.onCommandSlaveCreate = function (data) {
+SlaveController.prototype.onSocketMessage_status = function () {
+    this.socket.write(JSON.stringify({
+        type: "status",
+        status: this.testServer.getStatus()
+    }));
+};
+
+SlaveController.prototype.onSocketMessage_slaveCreate = function () {
     var slaveId = createSlaveId();
     var slaveInfo = this.slavesInfo[slaveId] = {
         slaveId: slaveId,
@@ -51,7 +60,10 @@ SlaveController.prototype.onCommandSlaveCreate = function (data) {
     slaveInfo.onSlaveIdle = this.onSlaveIdle.bind(this, slaveInfo);
     slaveInfo.onSlaveBusy = this.onSlaveBusy.bind(this, slaveInfo);
     this.testServer.on("slave-added-" + slaveId, slaveInfo.onSlaveConnect);
-    this.socket.emit("slaveCreated", slaveId);
+    this.socket.write(JSON.stringify({
+        type: "slaveCreated",
+        slaveId: slaveId
+    }));
 };
 
 var removeSlave = function (slaveInfo) {
@@ -65,7 +77,11 @@ var removeSlave = function (slaveInfo) {
     }
 };
 
-SlaveController.prototype.onCommandSlaveDelete = function (slaveId) {
+SlaveController.prototype.onSocketMessage_slaveDelete = function (data) {
+    this.deleteSlave(data.slaveId);
+};
+
+SlaveController.prototype.deleteSlave = function (slaveId) {
     if (!this.slavesInfo.hasOwnProperty(slaveId)) {
         return;
     }
@@ -74,7 +90,10 @@ SlaveController.prototype.onCommandSlaveDelete = function (slaveId) {
     removeSlave(slaveInfo);
     this.testServer.removeListener("slave-added-" + slaveId, slaveInfo.onSlaveConnect);
     if (this.socket) {
-        this.socket.emit("slaveDeleted", slaveId);
+        this.socket.write(JSON.stringify({
+            type: "slaveDeleted",
+            slaveId: slaveId
+        }));
     }
 };
 
@@ -84,8 +103,9 @@ SlaveController.prototype.onSlaveConnect = function (slaveInfo, slave) {
     slave.on("disconnect", slaveInfo.onSlaveDisconnect);
     slave.on("busy", slaveInfo.onSlaveBusy);
     slave.on("idle", slaveInfo.onSlaveIdle);
-    this.socket.emit("slaveConnected", {
-        id: slaveInfo.slaveId,
+    this.socket.write(JSON.stringify({
+        type: "slaveConnected",
+        slaveId: slaveInfo.slaveId,
         address: slave.address,
         port: slave.port,
         displayName: slave.displayName,
@@ -96,25 +116,34 @@ SlaveController.prototype.onSlaveConnect = function (slaveInfo, slave) {
                 browser: info.browser.getJsonInfo()
             };
         })
-    });
+    }));
 };
 
 SlaveController.prototype.onSlaveDisconnect = function (slaveInfo) {
     removeSlave(slaveInfo);
     if (this.socket) {
-        this.socket.emit("slaveDisconnected", slaveInfo.slaveId);
+        this.socket.write(JSON.stringify({
+            type: "slaveDisconnected",
+            slaveId: slaveInfo.slaveId
+        }));
     }
 };
 
 SlaveController.prototype.onSlaveIdle = function (slaveInfo) {
     if (this.socket) {
-        this.socket.emit("slaveIdle", slaveInfo.slaveId);
+        this.socket.write(JSON.stringify({
+            type: "slaveIdle",
+            slaveId: slaveInfo.slaveId
+        }));
     }
 };
 
 SlaveController.prototype.onSlaveBusy = function (slaveInfo) {
     if (this.socket) {
-        this.socket.emit("slaveBusy", slaveInfo.slaveId);
+        this.socket.write(JSON.stringify({
+            type: "slaveBusy",
+            slaveId: slaveInfo.slaveId
+        }));
     }
 };
 
@@ -122,7 +151,7 @@ SlaveController.prototype.onSocketDisconnect = function () {
     this.socket = null;
     var slavesInfo = this.slavesInfo;
     for (var slaveId in slavesInfo) {
-        this.onCommandSlaveDelete(slaveId);
+        this.deleteSlave(slaveId);
     }
     this.slavesInfo = null;
 };

--- a/lib/test-server/slave-server.js
+++ b/lib/test-server/slave-server.js
@@ -30,16 +30,6 @@ var allowedTestUpdateEvents = {
     "coverage": 1
 };
 
-var wrapInTryCatch = function (scope, fct) {
-    return function () {
-        try {
-            return fct.apply(scope, arguments);
-        } catch (e) {
-            console.log("Error when called from " + scope + ": ", e.stack || e);
-        }
-    };
-};
-
 var checkRestart = function (scope, task) {
     var restarts = task.restarts || 0;
     restarts++;
@@ -73,7 +63,7 @@ var campaignTaskFinished = function (scope) {
     }
     campaign.addResult(event);
     if (scope.socket) {
-        scope.socket.emit('slave-stop');
+        scope.socket.write('{"type":"slaveStop"}');
         scope.emitAvailable();
     }
 };
@@ -111,8 +101,8 @@ var Slave = function (socket, data, config, logger) {
     this.userAgent = data.userAgent;
     this.browserInfo = detectBrowser(data);
     this.displayName = this.browserInfo.displayName;
-    this.address = socket.conn.remoteAddress;
-    this.port = socket.request.connection.remotePort;
+    this.address = socket.remoteAddress;
+    this.port = socket.remotePort;
     this.addressName = null; // set by onReceiveAddressName
     this.taskExecutionId = null;
     this.currentTask = null;
@@ -127,14 +117,26 @@ var Slave = function (socket, data, config, logger) {
     this.matchingCampaignBrowsers = [];
 
     dns.reverse(this.address, this.onReceiveAddressName.bind(this));
-    socket.on('disconnect', wrapInTryCatch(this, this.onSocketDisconnected));
-    socket.on('test-update', wrapInTryCatch(this, this.onTestUpdate));
-    socket.on('task-finished', wrapInTryCatch(this, this.onTaskFinished));
-    socket.on('pause-changed', wrapInTryCatch(this, this.onPauseChanged));
-    socket.on('log', wrapInTryCatch(this, this.onClientLog));
+    socket.on('data', this.onSocketData.bind(this));
+    socket.on('close', this.onSocketDisconnected.bind(this));
 };
 
 util.inherits(Slave, events.EventEmitter);
+
+Slave.prototype.onSocketData = function (message) {
+    try {
+        var data = JSON.parse(message);
+        var type = data.type;
+        var handler = this["onSocketData_" + type];
+        if (handler) {
+            handler.call(this, data);
+        } else {
+            throw new Error("Unknown message type: " + type);
+        }
+    } catch (e) {
+        console.log("Error when called from " + this + ": ", e.stack || e);
+    }
+};
 
 Slave.prototype.toString = function () {
     var os = this.browserInfo.os.displayName;
@@ -173,7 +175,8 @@ Slave.prototype.assignTask = function (campaign, task) {
     this.emit('unavailable');
     task.slave = this;
     var test = task.test;
-    this.socket.emit('slave-execute', {
+    this.socket.write(JSON.stringify({
+        type: 'slaveExecute',
         url: test.url,
         name: test.name,
         taskId: task.taskId,
@@ -183,7 +186,7 @@ Slave.prototype.assignTask = function (campaign, task) {
             remainingTasks: campaign.remainingTasks,
             browserRemainingTasks: task.browser.pendingTasks
         }
-    });
+    }));
     this.currentCampaign.addResult({
         event: "taskStarted",
         taskId: task.taskId,
@@ -199,7 +202,9 @@ Slave.prototype.assignTask = function (campaign, task) {
     this.taskTimeoutId = setTimeout(this.taskTimeout.bind(this), this.config.taskTimeout);
 };
 
-Slave.prototype.onTestUpdate = function (event, taskExecutionId) {
+Slave.prototype.onSocketData_testUpdate = function (message) {
+    var event = message.event;
+    var taskExecutionId = message.taskExecutionId;
     var eventName = event.event;
     if (!this.checkTaskExecutionId(taskExecutionId, eventName)) {
         return;
@@ -213,7 +218,8 @@ Slave.prototype.onTestUpdate = function (event, taskExecutionId) {
     }
 };
 
-Slave.prototype.onPauseChanged = function (paused) {
+Slave.prototype.onSocketData_pauseChanged = function (message) {
+    var paused = message.paused;
     paused = !!paused; // makes sure it is a boolean
     if (this.paused !== paused) {
         this.paused = paused;
@@ -243,7 +249,9 @@ var clientLogLevels = {
     "error": Logger.LEVEL_ERROR
 };
 
-Slave.prototype.onClientLog = function (event, taskExecutionId) {
+Slave.prototype.onSocketData_log = function (message) {
+    var event = message.event;
+    var taskExecutionId = message.taskExecutionId;
     var eventLevel = event.level;
     var loggerLevel = +clientLogLevels[eventLevel];
     if (!isNaN(loggerLevel)) {
@@ -257,7 +265,8 @@ Slave.prototype.onClientLog = function (event, taskExecutionId) {
     }
 };
 
-Slave.prototype.onTaskFinished = function (taskExecutionId) {
+Slave.prototype.onSocketData_taskFinished = function (message) {
+    var taskExecutionId = message.taskExecutionId;
     if (!this.checkTaskExecutionId(taskExecutionId, "taskFinished")) {
         return;
     }
@@ -274,7 +283,7 @@ Slave.prototype.checkTaskExecutionId = function (taskExecutionId, eventName) {
 
 Slave.prototype.disconnect = function () {
     if (this.socket) {
-        this.socket.disconnect();
+        this.socket.close();
     }
 };
 
@@ -311,7 +320,7 @@ Slave.prototype.taskTimeout = function () {
 };
 
 Slave.prototype.dispose = function (callback) {
-    this.socket.emit('dispose');
+    this.socket.write('{"type":"dispose"}');
     // Give the slave some time to die
     setTimeout(function () {
         this.disconnect();

--- a/lib/test-server/test-server.js
+++ b/lib/test-server/test-server.js
@@ -22,7 +22,7 @@ var connect = require('connect');
 var compression = require('compression');
 var favicon = require('serve-favicon');
 var serveStatic = require('serve-static');
-var SocketIO = require('socket.io');
+var sockjs = require('sockjs');
 var _ = require("lodash");
 
 var attesterResultsUI = require('attester-results-ui');
@@ -66,12 +66,17 @@ var clientTypes = {
 
 var socketConnection = function (socket) {
     var testServer = this;
-    socket.once('hello', function (data) {
-        var fn = clientTypes[data.type];
-        if (fn) {
-            fn.call(testServer, socket, data);
-        } else {
-            // unknown hello message: close the connection so that the remote
+    socket.once('data', function (message) {
+        try {
+            var data = JSON.parse(message);
+            var fn = clientTypes[data.type];
+            if (fn) {
+                fn.call(testServer, socket, data);
+            } else {
+                throw new Error();
+            }
+        } catch (e) {
+            // unknown type or incorrect JSON: close the connection so that the remote
             // program knows it is not supported
             socket.close();
         }
@@ -199,9 +204,24 @@ var globalCoverage = function (req, res, next) {
     }
 };
 
+var createSockJSLogger = function (parentLogger) {
+    var logger = new Logger("sockjs", parentLogger);
+
+    var severityMap = {
+        "debug": Logger.LEVEL_DEBUG,
+        "info": Logger.LEVEL_INFO,
+        "error": Logger.LEVEL_ERROR
+    };
+
+    return function (severity, message) {
+        var level = severityMap[severity] || Logger.LEVEL_TRACE;
+        logger.log(level, message);
+    };
+};
+
 /**
  * A test server is a web server which browsers can connect to and become its slaves, ready to execute some tests.
- * Browsers connect to it through a socket.io channel.
+ * Browsers connect to it through a sockjs channel.
  * @param {Object} config Has the following properties:
  * <ul>
  * <li></li>
@@ -232,7 +252,7 @@ var TestServer = function (config, logger) {
     }));
     app.use('/__attester__', serveStatic(__dirname + '/client'));
     app.use('/__attester__/json3', serveStatic(path.dirname(require.resolve("json3/lib/json3.js"))));
-    app.use('/__attester__/js-polyfills', serveStatic(path.dirname(require.resolve("js-polyfills"))));
+    app.use('/__attester__/sockjs', serveStatic(path.dirname(require.resolve("sockjs-client/dist/sockjs.js"))));
     app.use('/__attester__/coverage/display', globalCoverage.bind(this));
     app.use('/__attester__/coverage/data', routeCoverage.bind(this));
     app.use('/__attester__/results-ui', attesterResultsUI({
@@ -242,8 +262,14 @@ var TestServer = function (config, logger) {
     app.use('/__attester__', jsonApi.bind(this));
     this.app = app;
     this.server = http.createServer(app);
-    this.socketio = new SocketIO(this.server);
-    this.socketio.on('connection', socketConnection.bind(this));
+    this.sockjs = sockjs.createServer();
+    this.sockjs.installHandlers(this.server, {
+        prefix: '/sockjs',
+        sockjs_url: '/__attester__/sockjs/sockjs.js',
+        disconnect_delay: 60000,
+        log: createSockJSLogger(this.logger)
+    });
+    this.sockjs.on('connection', socketConnection.bind(this));
     this.slaves = []; // array of all slaves
     this.availableSlaves = []; // array of available slaves
     this.campaigns = []; // array of campaigns

--- a/lib/test-server/viewer-server.js
+++ b/lib/test-server/viewer-server.js
@@ -24,15 +24,24 @@ var Viewer = function (socket, data, testServer) {
 
     this.onCampaignResult = this.onCampaignResult.bind(this);
     this.onSocketDisconnected = this.onSocketDisconnected.bind(this);
-    this.sendFirstResults = this.sendFirstResults.bind(this);
+    this.onSocketData = this.onSocketData.bind(this);
 
-    this.socket.on("disconnect", this.onSocketDisconnected);
+    this.socket.on("close", this.onSocketDisconnected);
 
     this.resultsSent = 0;
     this.allStoredResultsSent = false;
 
     this.sendFirstResults();
-    this.socket.on("firstResults", this.sendFirstResults);
+    this.socket.on("data", this.onSocketData);
+};
+
+Viewer.prototype.onSocketData = function (message) {
+    try {
+        var data = JSON.parse(message);
+        if (data.type === "firstResults") {
+            this.sendFirstResults();
+        }
+    } catch (e) {}
 };
 
 Viewer.prototype.sendFirstResults = function () {
@@ -44,10 +53,11 @@ Viewer.prototype.sendFirstResults = function () {
     for (var l = Math.min(i + 50, results.length); i < l; i++) {
         this.onCampaignResult(results[i]);
     }
-    this.socket.emit("firstResults", {
+    this.socket.write(JSON.stringify({
+        type: "firstResults",
         transmitted: i,
         total: results.length
-    });
+    }));
     if (i == results.length) {
         this.allStoredResultsSent = true;
         this.campaign.on("result", this.onCampaignResult);
@@ -56,7 +66,10 @@ Viewer.prototype.sendFirstResults = function () {
 
 Viewer.prototype.onCampaignResult = function (result) {
     this.resultsSent++;
-    this.socket.emit("result", result);
+    this.socket.write(JSON.stringify({
+        type: "result",
+        result: result
+    }));
 };
 
 Viewer.prototype.onSocketDisconnected = function () {

--- a/lib/util/detectHostname.js
+++ b/lib/util/detectHostname.js
@@ -53,8 +53,6 @@ module.exports = function (ipv4Only) {
                 return curResult.value[0];
             }
         }
-        // socket.io-client does not support IPv6 addresses yet
-        // (cf https://github.com/socketio/socket.io-client/pull/885)
         // so we currently only use IPv4 addresses when we cannot find the host name:
         var result = categories.IPv4.concat(categories.internalIPv4);
         return result[0];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2687 @@
+{
+    "name": "attester",
+    "version": "2.6.3",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "abbrev": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+            "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+            "dev": true
+        },
+        "accepts": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+            "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+            "requires": {
+                "mime-types": "2.1.15",
+                "negotiator": "0.6.1"
+            }
+        },
+        "align-text": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+            "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+            "requires": {
+                "kind-of": "3.2.2",
+                "longest": "1.0.1",
+                "repeat-string": "1.6.1"
+            }
+        },
+        "amdefine": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+            "dev": true
+        },
+        "angular": {
+            "version": "1.5.11",
+            "resolved": "https://registry.npmjs.org/angular/-/angular-1.5.11.tgz",
+            "integrity": "sha1-jFunOG8VllyazzQp9ogVU6raMNY="
+        },
+        "angular-ui-bootstrap": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/angular-ui-bootstrap/-/angular-ui-bootstrap-1.1.2.tgz",
+            "integrity": "sha1-U2LWa4suc1JqMS45jmrE5fqzCG8="
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+            "dev": true
+        },
+        "argparse": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+            "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+            "requires": {
+                "sprintf-js": "1.0.3"
+            }
+        },
+        "ariatemplates": {
+            "version": "1.7.22",
+            "resolved": "https://registry.npmjs.org/ariatemplates/-/ariatemplates-1.7.22.tgz",
+            "integrity": "sha1-KzEYKTfxuFBYgg7eD5R4psWade0=",
+            "dev": true,
+            "requires": {
+                "at-noder-converter": "1.0.1",
+                "atpackager": "0.2.7",
+                "gzip-js": "0.3.2",
+                "noder-js": "1.6.2"
+            }
+        },
+        "array-find-index": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+            "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+            "dev": true
+        },
+        "array-flatten": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+            "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+        },
+        "assertion-error": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
+            "integrity": "sha1-x/hUOP3UZrx8oWq5DIFRN5el0js=",
+            "dev": true
+        },
+        "async": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+            "dev": true
+        },
+        "at-noder-converter": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/at-noder-converter/-/at-noder-converter-1.0.1.tgz",
+            "integrity": "sha1-gZ/8m7pTTJeDq0ezHc7XA7QcdRs=",
+            "dev": true,
+            "requires": {
+                "optimist": "0.3.7",
+                "uglify-js": "2.4.24"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "0.2.10",
+                    "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                    "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+                    "dev": true
+                },
+                "optimist": {
+                    "version": "0.3.7",
+                    "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                    "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+                    "dev": true,
+                    "requires": {
+                        "wordwrap": "0.0.3"
+                    }
+                },
+                "source-map": {
+                    "version": "0.1.34",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+                    "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
+                    "dev": true,
+                    "requires": {
+                        "amdefine": "1.0.1"
+                    }
+                },
+                "uglify-js": {
+                    "version": "2.4.24",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+                    "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
+                    "dev": true,
+                    "requires": {
+                        "async": "0.2.10",
+                        "source-map": "0.1.34",
+                        "uglify-to-browserify": "1.0.2",
+                        "yargs": "3.5.4"
+                    }
+                },
+                "yargs": {
+                    "version": "3.5.4",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+                    "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "1.2.1",
+                        "decamelize": "1.2.0",
+                        "window-size": "0.1.0",
+                        "wordwrap": "0.0.2"
+                    },
+                    "dependencies": {
+                        "wordwrap": {
+                            "version": "0.0.2",
+                            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                            "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                            "dev": true
+                        }
+                    }
+                }
+            }
+        },
+        "atpackager": {
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/atpackager/-/atpackager-0.2.7.tgz",
+            "integrity": "sha1-O3Le5544lxjIF7/FoPCgmPGuZHg=",
+            "dev": true,
+            "requires": {
+                "murmurhash-js": "0.0.1",
+                "uglify-js": "2.4.13"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "0.2.10",
+                    "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                    "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+                    "dev": true
+                },
+                "optimist": {
+                    "version": "0.3.7",
+                    "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                    "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+                    "dev": true,
+                    "requires": {
+                        "wordwrap": "0.0.3"
+                    }
+                },
+                "source-map": {
+                    "version": "0.1.43",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                    "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+                    "dev": true,
+                    "requires": {
+                        "amdefine": "1.0.1"
+                    }
+                },
+                "uglify-js": {
+                    "version": "2.4.13",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.13.tgz",
+                    "integrity": "sha1-GN68nm7Pwg2xpeoDX4OdQ2pgWro=",
+                    "dev": true,
+                    "requires": {
+                        "async": "0.2.10",
+                        "optimist": "0.3.7",
+                        "source-map": "0.1.43",
+                        "uglify-to-browserify": "1.0.2"
+                    }
+                }
+            }
+        },
+        "attester-launcher": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/attester-launcher/-/attester-launcher-0.1.0.tgz",
+            "integrity": "sha512-qoSxut0M79Xlin4Lrzikb5PLBQqxYUhBUu2ulYUoX6u89m1JEhW6AijntE/n0dLeZGws32MenPjxmgUKLCD9tA==",
+            "requires": {
+                "colors": "0.6.2",
+                "js-yaml": "3.6.1",
+                "minimist": "1.2.0",
+                "q": "1.4.1",
+                "selenium-webdriver": "3.5.0",
+                "ws": "3.1.0"
+            }
+        },
+        "attester-results-ui": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/attester-results-ui/-/attester-results-ui-0.1.0.tgz",
+            "integrity": "sha512-Jx5/yKTXmLOvvTtdigaonziUnvHxwyeq6Ao7qEOYS+KkvmMjmxv8YFU/RncgCT50WoqlMZOOUjxwKuntVAGmIQ==",
+            "requires": {
+                "angular": "1.5.11",
+                "angular-ui-bootstrap": "1.1.2",
+                "bootstrap": "3.3.7",
+                "express": "4.14.1",
+                "glob": "4.3.5",
+                "optimist": "0.6.1",
+                "sockjs-client": "1.1.4"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "4.3.5",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+                    "integrity": "sha1-gPuwjKVA8jiszl0R0em8QedRc9M=",
+                    "requires": {
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "2.0.10",
+                        "once": "1.4.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "2.0.10",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                    "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+                    "requires": {
+                        "brace-expansion": "1.1.7"
+                    }
+                }
+            }
+        },
+        "balanced-match": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+            "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+        },
+        "bluebird": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+            "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+            "dev": true
+        },
+        "body-parser": {
+            "version": "1.14.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
+            "integrity": "sha1-EBXLH+LEQ4WCWVgdtTMy+NDPUPk=",
+            "dev": true,
+            "requires": {
+                "bytes": "2.2.0",
+                "content-type": "1.0.2",
+                "debug": "2.2.0",
+                "depd": "1.1.0",
+                "http-errors": "1.3.1",
+                "iconv-lite": "0.4.13",
+                "on-finished": "2.3.0",
+                "qs": "5.2.0",
+                "raw-body": "2.1.7",
+                "type-is": "1.6.15"
+            },
+            "dependencies": {
+                "bytes": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
+                    "integrity": "sha1-/TVGSkA/b5EXwt42Cez/nK4ABYg=",
+                    "dev": true
+                },
+                "http-errors": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+                    "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "statuses": "1.3.1"
+                    }
+                },
+                "iconv-lite": {
+                    "version": "0.4.13",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+                    "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
+                    "dev": true
+                },
+                "qs": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+                    "integrity": "sha1-qfMRQq9GjLcrJbMBNrokVoNJFr4=",
+                    "dev": true
+                }
+            }
+        },
+        "bootstrap": {
+            "version": "3.3.7",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
+            "integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E="
+        },
+        "brace-expansion": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+            "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+            "requires": {
+                "balanced-match": "0.4.2",
+                "concat-map": "0.0.1"
+            }
+        },
+        "builtin-modules": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+            "dev": true
+        },
+        "bytes": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz",
+            "integrity": "sha1-1baAoWW2IBc5rLYRVCqrwtjOsHA="
+        },
+        "camelcase": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+            "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+        },
+        "camelcase-keys": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+            "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+            "dev": true,
+            "requires": {
+                "camelcase": "2.1.1",
+                "map-obj": "1.0.1"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+                    "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+                    "dev": true
+                }
+            }
+        },
+        "center-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+            "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+            "requires": {
+                "align-text": "0.1.4",
+                "lazy-cache": "1.0.4"
+            }
+        },
+        "chai": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-1.9.2.tgz",
+            "integrity": "sha1-Pxog+CsLnXQ3V30k1vErGmnTtZA=",
+            "dev": true,
+            "requires": {
+                "assertion-error": "1.0.0",
+                "deep-eql": "0.1.3"
+            }
+        },
+        "chalk": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+            }
+        },
+        "cli": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+            "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+            "dev": true,
+            "requires": {
+                "exit": "0.1.2",
+                "glob": "7.1.2"
+            }
+        },
+        "cliui": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+            "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+            "requires": {
+                "center-align": "0.1.3",
+                "right-align": "0.1.3",
+                "wordwrap": "0.0.2"
+            },
+            "dependencies": {
+                "wordwrap": {
+                    "version": "0.0.2",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                    "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+                }
+            }
+        },
+        "coffee-script": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz",
+            "integrity": "sha1-EpOLz5vhlI+gBvkuDEyegXBRCMA=",
+            "dev": true
+        },
+        "colors": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+            "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
+        },
+        "commander": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-0.5.2.tgz",
+            "integrity": "sha1-8nAyZwmhFaEmz+1WI4UkObjko7U="
+        },
+        "compressible": {
+            "version": "2.0.10",
+            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.10.tgz",
+            "integrity": "sha1-/tocf3YXkScyspv4zyYlKiC57s0=",
+            "requires": {
+                "mime-db": "1.27.0"
+            }
+        },
+        "compression": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/compression/-/compression-1.6.2.tgz",
+            "integrity": "sha1-zOsSHsydCcUtetDDNQ6pPd1AK8M=",
+            "requires": {
+                "accepts": "1.3.3",
+                "bytes": "2.3.0",
+                "compressible": "2.0.10",
+                "debug": "2.2.0",
+                "on-headers": "1.0.1",
+                "vary": "1.1.1"
+            }
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "config-chain": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+            "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
+            "dev": true,
+            "requires": {
+                "ini": "1.3.4",
+                "proto-list": "1.2.4"
+            }
+        },
+        "connect": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz",
+            "integrity": "sha1-s1dSWgtMH1BZnNmD4dnv7qlncZg=",
+            "requires": {
+                "debug": "2.2.0",
+                "finalhandler": "0.5.0",
+                "parseurl": "1.3.1",
+                "utils-merge": "1.0.0"
+            },
+            "dependencies": {
+                "finalhandler": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
+                    "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
+                    "requires": {
+                        "debug": "2.2.0",
+                        "escape-html": "1.0.3",
+                        "on-finished": "2.3.0",
+                        "statuses": "1.3.1",
+                        "unpipe": "1.0.0"
+                    }
+                }
+            }
+        },
+        "connect-restreamer": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/connect-restreamer/-/connect-restreamer-1.0.3.tgz",
+            "integrity": "sha1-pz8E2I5yktf9Ly19aRoM3u7RQak="
+        },
+        "console-browserify": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+            "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+            "dev": true,
+            "requires": {
+                "date-now": "0.1.4"
+            }
+        },
+        "content-disposition": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+            "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+        },
+        "content-type": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+            "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0="
+        },
+        "cookie": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+            "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        },
+        "cookie-signature": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+            "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+        },
+        "core-js": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
+            "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU="
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "crc32": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/crc32/-/crc32-0.2.2.tgz",
+            "integrity": "sha1-etIg1v/c0Rn5/BJ6d3LKzqOQpLo=",
+            "dev": true
+        },
+        "currently-unhandled": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+            "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+            "dev": true,
+            "requires": {
+                "array-find-index": "1.0.2"
+            }
+        },
+        "date-now": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+            "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+            "dev": true
+        },
+        "dateformat": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+            "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+            "dev": true,
+            "requires": {
+                "get-stdin": "4.0.1",
+                "meow": "3.7.0"
+            }
+        },
+        "debug": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+            "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+            "requires": {
+                "ms": "0.7.1"
+            }
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+        },
+        "deep-eql": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+            "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+            "dev": true,
+            "requires": {
+                "type-detect": "0.1.1"
+            }
+        },
+        "deep-extend": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+            "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+            "dev": true
+        },
+        "deflate-js": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/deflate-js/-/deflate-js-0.2.3.tgz",
+            "integrity": "sha1-+Fq7WOvFFRowYUdHPVfD5PfkQms=",
+            "dev": true
+        },
+        "depd": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+            "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM="
+        },
+        "destroy": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+        },
+        "diff": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.2.tgz",
+            "integrity": "sha1-Suc/Gu6Nb89ITxoc53zmUdm38Mk=",
+            "dev": true
+        },
+        "dom-serializer": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+            "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+            "dev": true,
+            "requires": {
+                "domelementtype": "1.1.3",
+                "entities": "1.1.1"
+            },
+            "dependencies": {
+                "domelementtype": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                    "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+                    "dev": true
+                },
+                "entities": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+                    "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+                    "dev": true
+                }
+            }
+        },
+        "domelementtype": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+            "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+            "dev": true
+        },
+        "domhandler": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+            "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+            "dev": true,
+            "requires": {
+                "domelementtype": "1.3.0"
+            }
+        },
+        "domutils": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+            "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+            "dev": true,
+            "requires": {
+                "dom-serializer": "0.1.0",
+                "domelementtype": "1.3.0"
+            }
+        },
+        "editorconfig": {
+            "version": "0.13.2",
+            "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.2.tgz",
+            "integrity": "sha1-jleSbZ7mmrbLmZ8CfCFxRnrM6zU=",
+            "dev": true,
+            "requires": {
+                "bluebird": "3.5.0",
+                "commander": "2.9.0",
+                "lru-cache": "3.2.0",
+                "sigmund": "1.0.1"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.9.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                    "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-readlink": "1.0.1"
+                    }
+                }
+            }
+        },
+        "ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+        },
+        "encodeurl": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+            "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
+        },
+        "entities": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+            "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+            "dev": true
+        },
+        "error-ex": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+            "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+            "dev": true,
+            "requires": {
+                "is-arrayish": "0.2.1"
+            }
+        },
+        "es6-promise": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+            "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
+        },
+        "escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "esprima": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+            "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+        },
+        "etag": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+            "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg="
+        },
+        "eventemitter2": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-2.1.3.tgz",
+            "integrity": "sha1-vXIB+FxZVIOA4eQ7P2pyhtTac0k="
+        },
+        "eventsource": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
+            "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
+            "requires": {
+                "original": "1.0.0"
+            }
+        },
+        "exit": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+        },
+        "expect.js": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.3.1.tgz",
+            "integrity": "sha1-sKWaDS7/VDdUTr8M6qYBWEHQm1s=",
+            "dev": true
+        },
+        "express": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.14.1.tgz",
+            "integrity": "sha1-ZGwjf3ZvFIwhIK/wc4F7nk1+DTM=",
+            "requires": {
+                "accepts": "1.3.3",
+                "array-flatten": "1.1.1",
+                "content-disposition": "0.5.2",
+                "content-type": "1.0.2",
+                "cookie": "0.3.1",
+                "cookie-signature": "1.0.6",
+                "debug": "2.2.0",
+                "depd": "1.1.0",
+                "encodeurl": "1.0.1",
+                "escape-html": "1.0.3",
+                "etag": "1.7.0",
+                "finalhandler": "0.5.1",
+                "fresh": "0.3.0",
+                "merge-descriptors": "1.0.1",
+                "methods": "1.1.2",
+                "on-finished": "2.3.0",
+                "parseurl": "1.3.1",
+                "path-to-regexp": "0.1.7",
+                "proxy-addr": "1.1.5",
+                "qs": "6.2.0",
+                "range-parser": "1.2.0",
+                "send": "0.14.2",
+                "serve-static": "1.11.2",
+                "type-is": "1.6.15",
+                "utils-merge": "1.0.0",
+                "vary": "1.1.1"
+            },
+            "dependencies": {
+                "ms": {
+                    "version": "0.7.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+                    "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+                },
+                "send": {
+                    "version": "0.14.2",
+                    "resolved": "https://registry.npmjs.org/send/-/send-0.14.2.tgz",
+                    "integrity": "sha1-ObBDiz9RC+Xcb2Z6EfcWiTaM3u8=",
+                    "requires": {
+                        "debug": "2.2.0",
+                        "depd": "1.1.0",
+                        "destroy": "1.0.4",
+                        "encodeurl": "1.0.1",
+                        "escape-html": "1.0.3",
+                        "etag": "1.7.0",
+                        "fresh": "0.3.0",
+                        "http-errors": "1.5.1",
+                        "mime": "1.3.4",
+                        "ms": "0.7.2",
+                        "on-finished": "2.3.0",
+                        "range-parser": "1.2.0",
+                        "statuses": "1.3.1"
+                    }
+                },
+                "serve-static": {
+                    "version": "1.11.2",
+                    "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.2.tgz",
+                    "integrity": "sha1-LPmIm9RDWjIMw2iVyapXvWYuasc=",
+                    "requires": {
+                        "encodeurl": "1.0.1",
+                        "escape-html": "1.0.3",
+                        "parseurl": "1.3.1",
+                        "send": "0.14.2"
+                    }
+                }
+            }
+        },
+        "faye-websocket": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+            "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+            "requires": {
+                "websocket-driver": "0.6.5"
+            }
+        },
+        "fileset": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.8.tgz",
+            "integrity": "sha1-UGuRqTluqn4y+0KoQHfHoMc2t0E=",
+            "dev": true,
+            "requires": {
+                "glob": "3.2.11",
+                "minimatch": "0.4.0"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "3.2.11",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                    "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "minimatch": "0.3.0"
+                    },
+                    "dependencies": {
+                        "minimatch": {
+                            "version": "0.3.0",
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                            "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+                            "dev": true,
+                            "requires": {
+                                "lru-cache": "2.7.3",
+                                "sigmund": "1.0.1"
+                            }
+                        }
+                    }
+                },
+                "lru-cache": {
+                    "version": "2.7.3",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                    "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                    "dev": true
+                },
+                "minimatch": {
+                    "version": "0.4.0",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
+                    "integrity": "sha1-vSx9Bg0sjI/Xzefx8u0tWycP2xs=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "2.7.3",
+                        "sigmund": "1.0.1"
+                    }
+                }
+            }
+        },
+        "finalhandler": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.1.tgz",
+            "integrity": "sha1-LEANjUUwk1vCMlScX6OF7Afeb80=",
+            "requires": {
+                "debug": "2.2.0",
+                "escape-html": "1.0.3",
+                "on-finished": "2.3.0",
+                "statuses": "1.3.1",
+                "unpipe": "1.0.0"
+            }
+        },
+        "find-up": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+            "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+            "dev": true,
+            "requires": {
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
+            }
+        },
+        "findup-sync": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+            "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+            "dev": true,
+            "requires": {
+                "glob": "5.0.15"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "5.0.15",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                    "dev": true,
+                    "requires": {
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.3",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                }
+            }
+        },
+        "formidable": {
+            "version": "1.0.17",
+            "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
+            "integrity": "sha1-71SRSQ+UM7cF+qdyScmQKa40hVk="
+        },
+        "forwarded": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+            "integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M="
+        },
+        "fresh": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+            "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8="
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "gaze": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
+            "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
+            "dev": true,
+            "requires": {
+                "globule": "1.1.0"
+            }
+        },
+        "get-stdin": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+            "dev": true
+        },
+        "getobject": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+            "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
+            "dev": true
+        },
+        "glob": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+            },
+            "dependencies": {
+                "minimatch": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "requires": {
+                        "brace-expansion": "1.1.7"
+                    }
+                }
+            }
+        },
+        "globule": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz",
+            "integrity": "sha1-xJNS5NwYPYWJPuglOF65lLtt9F8=",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2",
+                "lodash": "4.16.6",
+                "minimatch": "3.0.3"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.16.6",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz",
+                    "integrity": "sha1-0iyaxmAojzhD4Wun0rXQbMon13c=",
+                    "dev": true
+                }
+            }
+        },
+        "graceful-fs": {
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+            "dev": true
+        },
+        "graceful-readlink": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+            "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+            "dev": true
+        },
+        "growl": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
+            "integrity": "sha1-3i1mE20ALhErpw8/EMMc98NQsto=",
+            "dev": true
+        },
+        "grunt": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.1.tgz",
+            "integrity": "sha1-6HeHZOlEsY8yuw8QuQeEdcnftWs=",
+            "dev": true,
+            "requires": {
+                "coffee-script": "1.10.0",
+                "dateformat": "1.0.12",
+                "eventemitter2": "0.4.14",
+                "exit": "0.1.2",
+                "findup-sync": "0.3.0",
+                "glob": "7.0.6",
+                "grunt-cli": "1.2.0",
+                "grunt-known-options": "1.1.0",
+                "grunt-legacy-log": "1.0.0",
+                "grunt-legacy-util": "1.0.0",
+                "iconv-lite": "0.4.17",
+                "js-yaml": "3.5.5",
+                "minimatch": "3.0.3",
+                "nopt": "3.0.6",
+                "path-is-absolute": "1.0.1",
+                "rimraf": "2.2.8"
+            },
+            "dependencies": {
+                "eventemitter2": {
+                    "version": "0.4.14",
+                    "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+                    "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+                    "dev": true
+                },
+                "glob": {
+                    "version": "7.0.6",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+                    "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.3",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "js-yaml": {
+                    "version": "3.5.5",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
+                    "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
+                    "dev": true,
+                    "requires": {
+                        "argparse": "1.0.9",
+                        "esprima": "2.7.3"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.2.8",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                    "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+                    "dev": true
+                }
+            }
+        },
+        "grunt-cli": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
+            "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
+            "dev": true,
+            "requires": {
+                "findup-sync": "0.3.0",
+                "grunt-known-options": "1.1.0",
+                "nopt": "3.0.6",
+                "resolve": "1.1.7"
+            }
+        },
+        "grunt-contrib-jshint": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-1.0.0.tgz",
+            "integrity": "sha1-MPQFpR3mVr+m6wKbmkZLn+AqQCo=",
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3",
+                "hooker": "0.2.3",
+                "jshint": "2.9.4"
+            }
+        },
+        "grunt-contrib-watch": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-1.0.0.tgz",
+            "integrity": "sha1-hKGnodar0m7VaEE0lscxM+mQAY8=",
+            "dev": true,
+            "requires": {
+                "async": "1.5.2",
+                "gaze": "1.1.2",
+                "lodash": "3.10.1",
+                "tiny-lr": "0.2.1"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "3.10.1",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                    "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+                    "dev": true
+                }
+            }
+        },
+        "grunt-jsbeautifier": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/grunt-jsbeautifier/-/grunt-jsbeautifier-0.2.13.tgz",
+            "integrity": "sha1-89QXOPy1+ZhO8pbVvuvEBIkQVkI=",
+            "dev": true,
+            "requires": {
+                "async": "2.4.1",
+                "grunt": "1.0.1",
+                "js-beautify": "1.6.4",
+                "lodash": "4.15.0",
+                "rc": "1.2.1",
+                "semver": "5.3.0",
+                "underscore.string": "3.2.3"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
+                    "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c=",
+                    "dev": true,
+                    "requires": {
+                        "lodash": "4.15.0"
+                    }
+                },
+                "semver": {
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+                    "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+                    "dev": true
+                }
+            }
+        },
+        "grunt-known-options": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.0.tgz",
+            "integrity": "sha1-pCdO6zL6dl2lp6OxcSYXzjsUQUk=",
+            "dev": true
+        },
+        "grunt-legacy-log": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.0.tgz",
+            "integrity": "sha1-+4bxgJhHvAfcR4Q/ns1srLYt8tU=",
+            "dev": true,
+            "requires": {
+                "colors": "1.1.2",
+                "grunt-legacy-log-utils": "1.0.0",
+                "hooker": "0.2.3",
+                "lodash": "3.10.1",
+                "underscore.string": "3.2.3"
+            },
+            "dependencies": {
+                "colors": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+                    "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+                    "dev": true
+                },
+                "lodash": {
+                    "version": "3.10.1",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                    "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+                    "dev": true
+                }
+            }
+        },
+        "grunt-legacy-log-utils": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-1.0.0.tgz",
+            "integrity": "sha1-p7ji0Ps1taUPSvmG/BEnSevJbz0=",
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3",
+                "lodash": "4.3.0"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
+                    "integrity": "sha1-79nEpuxT87BUEkKZFcPkgk5NJaQ=",
+                    "dev": true
+                }
+            }
+        },
+        "grunt-legacy-util": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.0.0.tgz",
+            "integrity": "sha1-OGqnjcbtUJhsKxiVcmWxtIq7m4Y=",
+            "dev": true,
+            "requires": {
+                "async": "1.5.2",
+                "exit": "0.1.2",
+                "getobject": "0.1.0",
+                "hooker": "0.2.3",
+                "lodash": "4.3.0",
+                "underscore.string": "3.2.3",
+                "which": "1.2.14"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
+                    "integrity": "sha1-79nEpuxT87BUEkKZFcPkgk5NJaQ=",
+                    "dev": true
+                }
+            }
+        },
+        "gzip-js": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/gzip-js/-/gzip-js-0.3.2.tgz",
+            "integrity": "sha1-IxF+/usozzhSSN7/Df+tiUg22Ws=",
+            "dev": true,
+            "requires": {
+                "crc32": "0.2.2",
+                "deflate-js": "0.2.3"
+            }
+        },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "2.1.1"
+            }
+        },
+        "hooker": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+            "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+            "dev": true
+        },
+        "hosted-git-info": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
+            "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
+            "dev": true
+        },
+        "htmlparser2": {
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+            "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+            "dev": true,
+            "requires": {
+                "domelementtype": "1.3.0",
+                "domhandler": "2.3.0",
+                "domutils": "1.5.1",
+                "entities": "1.0.0",
+                "readable-stream": "1.1.14"
+            }
+        },
+        "http-errors": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+            "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
+            "requires": {
+                "inherits": "2.0.3",
+                "setprototypeof": "1.0.2",
+                "statuses": "1.3.1"
+            }
+        },
+        "http-proxy": {
+            "version": "0.8.7",
+            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.8.7.tgz",
+            "integrity": "sha1-p7xThhgJLNJu0ZHkYlkzuu9t6A4=",
+            "requires": {
+                "colors": "0.6.2",
+                "optimist": "0.3.7",
+                "pkginfo": "0.2.3"
+            },
+            "dependencies": {
+                "optimist": {
+                    "version": "0.3.7",
+                    "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                    "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+                    "requires": {
+                        "wordwrap": "0.0.3"
+                    }
+                }
+            }
+        },
+        "iconv-lite": {
+            "version": "0.4.17",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.17.tgz",
+            "integrity": "sha1-T9qjs4rLwsAxsEXQ7c3+HsqxjI0=",
+            "dev": true
+        },
+        "immediate": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+            "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+        },
+        "indent-string": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+            "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+            "dev": true,
+            "requires": {
+                "repeating": "2.0.1"
+            }
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+            }
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "ini": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+            "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+            "dev": true
+        },
+        "ipaddr.js": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
+            "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA="
+        },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
+        },
+        "is-buffer": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+            "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+        },
+        "is-builtin-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+            "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+            "dev": true,
+            "requires": {
+                "builtin-modules": "1.1.1"
+            }
+        },
+        "is-finite": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+            "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+            "dev": true,
+            "requires": {
+                "number-is-nan": "1.0.1"
+            }
+        },
+        "is-utf8": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+            "dev": true
+        },
+        "isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+            "dev": true
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "jade": {
+            "version": "0.20.3",
+            "resolved": "https://registry.npmjs.org/jade/-/jade-0.20.3.tgz",
+            "integrity": "sha1-f0PLxxA3Yqu3Kmf9ZITrcqwdKKA=",
+            "requires": {
+                "commander": "0.5.2",
+                "mkdirp": "0.3.5"
+            }
+        },
+        "jasmine-growl-reporter": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/jasmine-growl-reporter/-/jasmine-growl-reporter-0.0.3.tgz",
+            "integrity": "sha1-uHrlUeNZ0orVIXdl6u9sB7dj9sg=",
+            "dev": true,
+            "requires": {
+                "growl": "1.7.0"
+            }
+        },
+        "jasmine-node": {
+            "version": "1.14.5",
+            "resolved": "https://registry.npmjs.org/jasmine-node/-/jasmine-node-1.14.5.tgz",
+            "integrity": "sha1-GOg5e4VpJO53ADZmw3MbWupQw50=",
+            "dev": true,
+            "requires": {
+                "coffee-script": "1.10.0",
+                "gaze": "0.3.4",
+                "jasmine-growl-reporter": "0.0.3",
+                "jasmine-reporters": "1.0.2",
+                "mkdirp": "0.3.5",
+                "requirejs": "2.3.3",
+                "underscore": "1.8.3",
+                "walkdir": "0.0.11"
+            },
+            "dependencies": {
+                "gaze": {
+                    "version": "0.3.4",
+                    "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.3.4.tgz",
+                    "integrity": "sha1-X5S92gr+U7xxCWm81vKCVI1gwnk=",
+                    "dev": true,
+                    "requires": {
+                        "fileset": "0.1.8",
+                        "minimatch": "0.2.14"
+                    }
+                },
+                "lru-cache": {
+                    "version": "2.7.3",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                    "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                    "dev": true
+                },
+                "minimatch": {
+                    "version": "0.2.14",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                    "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "2.7.3",
+                        "sigmund": "1.0.1"
+                    }
+                }
+            }
+        },
+        "jasmine-reporters": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/jasmine-reporters/-/jasmine-reporters-1.0.2.tgz",
+            "integrity": "sha1-q2E+1Zd9x0h+hbPBL2qOqNsq3jE=",
+            "dev": true,
+            "requires": {
+                "mkdirp": "0.3.5"
+            }
+        },
+        "js-beautify": {
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.4.tgz",
+            "integrity": "sha1-qa95aZdCrJobb93B/bx4vE1RX8M=",
+            "dev": true,
+            "requires": {
+                "config-chain": "1.1.11",
+                "editorconfig": "0.13.2",
+                "mkdirp": "0.5.1",
+                "nopt": "3.0.6"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                }
+            }
+        },
+        "js-yaml": {
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+            "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+            "requires": {
+                "argparse": "1.0.9",
+                "esprima": "2.7.3"
+            }
+        },
+        "jshint": {
+            "version": "2.9.4",
+            "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.4.tgz",
+            "integrity": "sha1-XjupeEjVKQJz21FK7kf+JM9ZKTQ=",
+            "dev": true,
+            "requires": {
+                "cli": "1.0.1",
+                "console-browserify": "1.1.0",
+                "exit": "0.1.2",
+                "htmlparser2": "3.8.3",
+                "lodash": "3.7.0",
+                "minimatch": "3.0.3",
+                "shelljs": "0.3.0",
+                "strip-json-comments": "1.0.4"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "3.7.0",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+                    "integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
+                    "dev": true
+                }
+            }
+        },
+        "json3": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+            "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+        },
+        "jszip": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.3.tgz",
+            "integrity": "sha1-ipIEA7KxZRwPwSa+kBktkICVfDc=",
+            "requires": {
+                "core-js": "2.3.0",
+                "es6-promise": "3.0.2",
+                "lie": "3.1.1",
+                "pako": "1.0.5",
+                "readable-stream": "2.0.6"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                },
+                "readable-stream": {
+                    "version": "2.0.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                    "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "0.10.31",
+                        "util-deprecate": "1.0.2"
+                    }
+                }
+            }
+        },
+        "kind-of": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+            "requires": {
+                "is-buffer": "1.1.5"
+            }
+        },
+        "lazy-cache": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+        },
+        "lie": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+            "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+            "requires": {
+                "immediate": "3.0.6"
+            }
+        },
+        "livereload-js": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz",
+            "integrity": "sha1-bIclfmSKtHW8JOoldFftzB+NC8I=",
+            "dev": true
+        },
+        "load-json-file": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+            "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "strip-bom": "2.0.0"
+            }
+        },
+        "lodash": {
+            "version": "4.15.0",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
+            "integrity": "sha1-MWI5HY8BQKoiz49rPDTWt/Y9Oqk="
+        },
+        "longest": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+            "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+        },
+        "loud-rejection": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+            "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+            "dev": true,
+            "requires": {
+                "currently-unhandled": "0.4.1",
+                "signal-exit": "3.0.2"
+            }
+        },
+        "lru-cache": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+            "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
+            "dev": true,
+            "requires": {
+                "pseudomap": "1.0.2"
+            }
+        },
+        "map-obj": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+            "dev": true
+        },
+        "media-typer": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+        },
+        "meow": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+            "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+            "dev": true,
+            "requires": {
+                "camelcase-keys": "2.1.0",
+                "decamelize": "1.2.0",
+                "loud-rejection": "1.6.0",
+                "map-obj": "1.0.1",
+                "minimist": "1.2.0",
+                "normalize-package-data": "2.3.8",
+                "object-assign": "4.1.1",
+                "read-pkg-up": "1.0.1",
+                "redent": "1.0.0",
+                "trim-newlines": "1.0.0"
+            }
+        },
+        "merge-descriptors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+            "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+        },
+        "methods": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+            "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+        },
+        "mime": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+            "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+        },
+        "mime-db": {
+            "version": "1.27.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+            "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+        },
+        "mime-types": {
+            "version": "2.1.15",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+            "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+            "requires": {
+                "mime-db": "1.27.0"
+            }
+        },
+        "minimatch": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+            "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+            "requires": {
+                "brace-expansion": "1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "mkdirp": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+            "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
+        },
+        "mocha": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.8.1.tgz",
+            "integrity": "sha1-+m8FbMMoL1XsKsa+J7MuME1h4v4=",
+            "dev": true,
+            "requires": {
+                "commander": "0.6.1",
+                "debug": "2.2.0",
+                "diff": "1.0.2",
+                "growl": "1.7.0",
+                "jade": "0.26.3",
+                "mkdirp": "0.3.3",
+                "ms": "0.3.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+                    "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+                    "dev": true
+                },
+                "jade": {
+                    "version": "0.26.3",
+                    "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+                    "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+                    "dev": true,
+                    "requires": {
+                        "commander": "0.6.1",
+                        "mkdirp": "0.3.0"
+                    },
+                    "dependencies": {
+                        "mkdirp": {
+                            "version": "0.3.0",
+                            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+                            "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+                            "dev": true
+                        }
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.3.3",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.3.tgz",
+                    "integrity": "sha1-WV4lHBNww6aLqyE20ONIuBBa3xM=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.3.0.tgz",
+                    "integrity": "sha1-A+3DSNYT5mpWSGz9rFO8vomcvWE=",
+                    "dev": true
+                }
+            }
+        },
+        "ms": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+            "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+        },
+        "murmurhash-js": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-0.0.1.tgz",
+            "integrity": "sha1-FF2FZ3NyHnZ0KVMarv73BsBmkBU=",
+            "dev": true
+        },
+        "negotiator": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+            "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+        },
+        "node-coverage": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/node-coverage/-/node-coverage-1.0.7.tgz",
+            "integrity": "sha1-PNoSMP4+lPKO2fBaKRqm+e3lXx4=",
+            "requires": {
+                "connect": "1.9.2",
+                "connect-restreamer": "1.0.3",
+                "express": "2.5.11",
+                "http-proxy": "0.8.7",
+                "jade": "0.20.3",
+                "mkdirp": "0.3.5",
+                "optimist": "0.3.7",
+                "uglify-js": "1.2.6"
+            },
+            "dependencies": {
+                "connect": {
+                    "version": "1.9.2",
+                    "resolved": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
+                    "integrity": "sha1-QogKIulDiuWait105Df1iujlKAc=",
+                    "requires": {
+                        "formidable": "1.0.17",
+                        "mime": "1.3.4",
+                        "qs": "6.2.0"
+                    }
+                },
+                "express": {
+                    "version": "2.5.11",
+                    "resolved": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
+                    "integrity": "sha1-TOjqHzY15p5J8Ou0l7aksKUc5vA=",
+                    "requires": {
+                        "connect": "1.9.2",
+                        "mime": "1.2.4",
+                        "mkdirp": "0.3.0",
+                        "qs": "0.4.2"
+                    },
+                    "dependencies": {
+                        "mime": {
+                            "version": "1.2.4",
+                            "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz",
+                            "integrity": "sha1-EbX9rynCUJJVF2uArVIClPXekrc="
+                        },
+                        "mkdirp": {
+                            "version": "0.3.0",
+                            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+                            "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4="
+                        },
+                        "qs": {
+                            "version": "0.4.2",
+                            "resolved": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz",
+                            "integrity": "sha1-PKxMhh43GoycR3CsI82o3mObjl8="
+                        }
+                    }
+                },
+                "optimist": {
+                    "version": "0.3.7",
+                    "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                    "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+                    "requires": {
+                        "wordwrap": "0.0.3"
+                    }
+                },
+                "uglify-js": {
+                    "version": "1.2.6",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.6.tgz",
+                    "integrity": "sha1-01Sy08HPEOvBj6eMEaKL3ZzhWA0="
+                }
+            }
+        },
+        "noder-js": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/noder-js/-/noder-js-1.6.2.tgz",
+            "integrity": "sha1-q5esyOwgEhe9SKaoEtwf8gfhxog="
+        },
+        "nopt": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+            "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+            "dev": true,
+            "requires": {
+                "abbrev": "1.1.0"
+            }
+        },
+        "normalize-package-data": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
+            "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
+            "dev": true,
+            "requires": {
+                "hosted-git-info": "2.4.2",
+                "is-builtin-module": "1.0.0",
+                "semver": "2.3.1",
+                "validate-npm-package-license": "3.0.1"
+            }
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
+        "on-finished": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+            "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+            "requires": {
+                "ee-first": "1.1.1"
+            }
+        },
+        "on-headers": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+            "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "requires": {
+                "wrappy": "1.0.2"
+            }
+        },
+        "optimist": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+            "requires": {
+                "minimist": "0.0.10",
+                "wordwrap": "0.0.3"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.10",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                    "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+                }
+            }
+        },
+        "original": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
+            "integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
+            "requires": {
+                "url-parse": "1.0.5"
+            },
+            "dependencies": {
+                "url-parse": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
+                    "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
+                    "requires": {
+                        "querystringify": "0.0.4",
+                        "requires-port": "1.0.0"
+                    }
+                }
+            }
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+        },
+        "pako": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.5.tgz",
+            "integrity": "sha1-0iBd/ludqK95fnwWPbTR+E5GALw="
+        },
+        "parse-json": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+            "dev": true,
+            "requires": {
+                "error-ex": "1.3.1"
+            }
+        },
+        "parseurl": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+            "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
+        },
+        "path-exists": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+            "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+            "dev": true,
+            "requires": {
+                "pinkie-promise": "2.0.1"
+            }
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "path-to-regexp": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+            "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+        },
+        "path-type": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+            "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
+            }
+        },
+        "pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "dev": true
+        },
+        "pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
+        },
+        "pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true,
+            "requires": {
+                "pinkie": "2.0.4"
+            }
+        },
+        "pkginfo": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz",
+            "integrity": "sha1-cjnEKl72wwuPMoQ52bn/cQQkkPg="
+        },
+        "process-nextick-args": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        },
+        "proto-list": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+            "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+            "dev": true
+        },
+        "proxy-addr": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
+            "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
+            "requires": {
+                "forwarded": "0.1.0",
+                "ipaddr.js": "1.4.0"
+            }
+        },
+        "pseudomap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+            "dev": true
+        },
+        "q": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+            "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
+        },
+        "qs": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
+            "integrity": "sha1-O3hIwDwt7OaalSKw+ujEEm10Xzs="
+        },
+        "querystringify": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
+            "integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw="
+        },
+        "range-parser": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+            "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+        },
+        "raw-body": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+            "integrity": "sha1-rf6s4uT7MJgFgBTQjActzFl1h3Q=",
+            "dev": true,
+            "requires": {
+                "bytes": "2.4.0",
+                "iconv-lite": "0.4.13",
+                "unpipe": "1.0.0"
+            },
+            "dependencies": {
+                "bytes": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+                    "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk=",
+                    "dev": true
+                },
+                "iconv-lite": {
+                    "version": "0.4.13",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+                    "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
+                    "dev": true
+                }
+            }
+        },
+        "rc": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+            "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+            "dev": true,
+            "requires": {
+                "deep-extend": "0.4.2",
+                "ini": "1.3.4",
+                "minimist": "1.2.0",
+                "strip-json-comments": "2.0.1"
+            },
+            "dependencies": {
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                    "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+                    "dev": true
+                }
+            }
+        },
+        "read-pkg": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+            "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+            "dev": true,
+            "requires": {
+                "load-json-file": "1.1.0",
+                "normalize-package-data": "2.3.8",
+                "path-type": "1.1.0"
+            }
+        },
+        "read-pkg-up": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+            "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+            "dev": true,
+            "requires": {
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
+            }
+        },
+        "readable-stream": {
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+            "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+            "dev": true,
+            "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+            }
+        },
+        "redent": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+            "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+            "dev": true,
+            "requires": {
+                "indent-string": "2.1.0",
+                "strip-indent": "1.0.1"
+            }
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+        },
+        "repeating": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+            "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+            "dev": true,
+            "requires": {
+                "is-finite": "1.0.2"
+            }
+        },
+        "requirejs": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.3.tgz",
+            "integrity": "sha1-qln9OgKH6vQHlZoTgigES13WpqM=",
+            "dev": true
+        },
+        "requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+        },
+        "resolve": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+            "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+            "dev": true
+        },
+        "right-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+            "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+            "requires": {
+                "align-text": "0.1.4"
+            }
+        },
+        "rimraf": {
+            "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+            "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+            "requires": {
+                "glob": "7.1.2"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+        },
+        "sax": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz",
+            "integrity": "sha1-VjsZx8HeiS4Jv8Ty/DDjwn8JUrk="
+        },
+        "selenium-webdriver": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-3.5.0.tgz",
+            "integrity": "sha512-1bCZYRfDy7vsu1dkLrclTLvWPxSo6rOIkxZXvB2wnzeWkEoiTKpw612EUGA3jRZxPzAzI9OlxuULJV8ge1vVXQ==",
+            "requires": {
+                "jszip": "3.1.3",
+                "rimraf": "2.5.4",
+                "tmp": "0.0.30",
+                "xml2js": "0.4.17"
+            }
+        },
+        "semver": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.1.tgz",
+            "integrity": "sha1-b2XufRrtdTzfndpw5WMaP7QqW+4="
+        },
+        "send": {
+            "version": "0.14.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
+            "integrity": "sha1-qVSYQyU5L1FTKndgdg5FlZjIn3o=",
+            "requires": {
+                "debug": "2.2.0",
+                "depd": "1.1.0",
+                "destroy": "1.0.4",
+                "encodeurl": "1.0.1",
+                "escape-html": "1.0.3",
+                "etag": "1.7.0",
+                "fresh": "0.3.0",
+                "http-errors": "1.5.1",
+                "mime": "1.3.4",
+                "ms": "0.7.1",
+                "on-finished": "2.3.0",
+                "range-parser": "1.2.0",
+                "statuses": "1.3.1"
+            }
+        },
+        "serve-favicon": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.0.tgz",
+            "integrity": "sha1-rtNsxoNAaabxicxyIsahqBHcWzk=",
+            "requires": {
+                "etag": "1.7.0",
+                "fresh": "0.3.0",
+                "ms": "0.7.1",
+                "parseurl": "1.3.1"
+            }
+        },
+        "serve-static": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
+            "integrity": "sha1-1sznaTUF9zPHWd5Xvvwa92wPCAU=",
+            "requires": {
+                "encodeurl": "1.0.1",
+                "escape-html": "1.0.3",
+                "parseurl": "1.3.1",
+                "send": "0.14.1"
+            }
+        },
+        "setprototypeof": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
+            "integrity": "sha1-gaVSFB7BBLiOic44MQOtXGZWTQg="
+        },
+        "shelljs": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+            "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+            "dev": true
+        },
+        "sigmund": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+            "dev": true
+        },
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "dev": true
+        },
+        "sockjs": {
+            "version": "0.3.18",
+            "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
+            "integrity": "sha1-2bKJMWyn33dZXvKZ4HXw+TfrQgc=",
+            "requires": {
+                "faye-websocket": "0.10.0",
+                "uuid": "2.0.3"
+            }
+        },
+        "sockjs-client": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
+            "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
+            "requires": {
+                "debug": "2.6.8",
+                "eventsource": "0.1.6",
+                "faye-websocket": "0.11.1",
+                "inherits": "2.0.3",
+                "json3": "3.3.2",
+                "url-parse": "1.1.9"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.8",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                    "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "faye-websocket": {
+                    "version": "0.11.1",
+                    "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+                    "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+                    "requires": {
+                        "websocket-driver": "0.6.5"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                }
+            }
+        },
+        "source-map": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "spdx-correct": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+            "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+            "dev": true,
+            "requires": {
+                "spdx-license-ids": "1.2.2"
+            }
+        },
+        "spdx-expression-parse": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+            "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+            "dev": true
+        },
+        "spdx-license-ids": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+            "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+            "dev": true
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+        },
+        "statuses": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+            "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+        },
+        "string_decoder": {
+            "version": "0.10.31",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "2.1.1"
+            }
+        },
+        "strip-bom": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+            "dev": true,
+            "requires": {
+                "is-utf8": "0.2.1"
+            }
+        },
+        "strip-indent": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+            "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+            "dev": true,
+            "requires": {
+                "get-stdin": "4.0.1"
+            }
+        },
+        "strip-json-comments": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+            "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+            "dev": true
+        },
+        "supports-color": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+            "dev": true
+        },
+        "tiny-lr": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.2.1.tgz",
+            "integrity": "sha1-s/26gC5dVqM8L28QeUsy5Hescp0=",
+            "dev": true,
+            "requires": {
+                "body-parser": "1.14.2",
+                "debug": "2.2.0",
+                "faye-websocket": "0.10.0",
+                "livereload-js": "2.2.2",
+                "parseurl": "1.3.1",
+                "qs": "5.1.0"
+            },
+            "dependencies": {
+                "qs": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz",
+                    "integrity": "sha1-TZMuXH6kEcynajEtOaYGIA/VDNk=",
+                    "dev": true
+                }
+            }
+        },
+        "tmp": {
+            "version": "0.0.30",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.30.tgz",
+            "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
+            "requires": {
+                "os-tmpdir": "1.0.2"
+            }
+        },
+        "trim-newlines": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+            "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+            "dev": true
+        },
+        "type-detect": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+            "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+            "dev": true
+        },
+        "type-is": {
+            "version": "1.6.15",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+            "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+            "requires": {
+                "media-typer": "0.3.0",
+                "mime-types": "2.1.15"
+            }
+        },
+        "ua-parser-js": {
+            "version": "0.7.10",
+            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.10.tgz",
+            "integrity": "sha1-kXVZ3czgfLwJ7OfYBJXkwmj0758="
+        },
+        "uglify-js": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.3.tgz",
+            "integrity": "sha1-ObOnMpuJ9exQfjRMbiJWhpjvSGg=",
+            "requires": {
+                "async": "0.2.10",
+                "source-map": "0.5.6",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "0.2.10",
+                    "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                    "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+                }
+            }
+        },
+        "uglify-to-browserify": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+            "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
+        },
+        "ultron": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
+            "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ="
+        },
+        "underscore": {
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+            "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+            "dev": true
+        },
+        "underscore.string": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz",
+            "integrity": "sha1-gGmSYzZl1eX8tNsfs6hi62jp5to=",
+            "dev": true
+        },
+        "unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+        },
+        "url-parse": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
+            "integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
+            "requires": {
+                "querystringify": "1.0.0",
+                "requires-port": "1.0.0"
+            },
+            "dependencies": {
+                "querystringify": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
+                    "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs="
+                }
+            }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "utils-merge": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+            "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+        },
+        "uuid": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+            "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+            "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+            "dev": true,
+            "requires": {
+                "spdx-correct": "1.0.2",
+                "spdx-expression-parse": "1.0.4"
+            }
+        },
+        "vary": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
+            "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc="
+        },
+        "walkdir": {
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
+            "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
+            "dev": true
+        },
+        "websocket-driver": {
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
+            "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
+            "requires": {
+                "websocket-extensions": "0.1.1"
+            }
+        },
+        "websocket-extensions": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
+            "integrity": "sha1-domUmcGEtu91Q3fC27DNbLVdKec="
+        },
+        "which": {
+            "version": "1.2.14",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+            "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+            "dev": true,
+            "requires": {
+                "isexe": "2.0.0"
+            }
+        },
+        "window-size": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+            "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+        },
+        "wordwrap": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "ws": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-3.1.0.tgz",
+            "integrity": "sha512-TU4/qKFlyQFqNITNWiqPCUY9GqlAhEotlzfcZcve6VT1YEngQl1dDMqwQQS3eMYruJ5r/UD3lcsWib6iVMDGDw==",
+            "requires": {
+                "safe-buffer": "5.1.1",
+                "ultron": "1.1.0"
+            }
+        },
+        "xml2js": {
+            "version": "0.4.17",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+            "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+            "requires": {
+                "sax": "0.6.1",
+                "xmlbuilder": "4.2.1"
+            },
+            "dependencies": {
+                "xmlbuilder": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+                    "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+                    "requires": {
+                        "lodash": "4.15.0"
+                    }
+                }
+            }
+        },
+        "yargs": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+            "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+            "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "window-size": "0.1.0"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -26,14 +26,13 @@
     },
     "main": "./lib/attester.js",
     "dependencies": {
-        "attester-launcher": "0.0.10",
-        "attester-results-ui": "0.0.12",
+        "attester-launcher": "0.1.0",
+        "attester-results-ui": "0.1.0",
         "colors": "0.6.2",
         "compression": "1.6.2",
         "connect": "3.5.0",
         "eventemitter2": "2.1.3",
         "exit": "0.1.2",
-        "js-polyfills": "0.1.22",
         "js-yaml": "3.6.1",
         "json3": "3.3.2",
         "lodash": "4.15.0",
@@ -46,7 +45,8 @@
         "send": "0.14.1",
         "serve-favicon": "2.3.0",
         "serve-static": "1.11.1",
-        "socket.io": "1.4.8",
+        "sockjs": "^0.3.18",
+        "sockjs-client": "^1.1.4",
         "ua-parser-js": "0.7.10",
         "uglify-js": "2.7.3"
     },
@@ -71,6 +71,6 @@
         "test": "npm run grunt-test && npm run jasmine-test"
     },
     "engines": {
-        "node": ">=4.2.1"
+        "node": ">=6.9.1"
     }
 }

--- a/spec/cli/cli.spec.js
+++ b/spec/cli/cli.spec.js
@@ -432,6 +432,7 @@ describe('cli', function () {
 
     itRuns({
         testCase: 'browser disconnected (1 restart)',
+        timeout: 20000,
         exitCode: 1,
         args: ['--max-task-restarts', '1', '--config.tests.mocha.files.includes', 'spec/test-type/mocha/extraScripts/disconnect.js'],
         results: {
@@ -537,7 +538,7 @@ describe('cli', function () {
 
     if (process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY) {
         var saucelabsBrowsers = [];
-        ["Firefox >= 41 as Firefox", "Chrome", "Safari", "Edge", "IE 11", "IE 10", "IE 9", "IE 8", "IE 7", "Firefox 11"].forEach(function (browserName) {
+        ["Firefox >= 41 as Firefox", "Chrome", "Safari", "Edge", "IE 11", "IE 10", "IE 9", "IE 8", "Firefox 11"].forEach(function (browserName) {
             saucelabsBrowsers.push("--config.browsers");
             saucelabsBrowsers.push(browserName);
         });
@@ -548,7 +549,7 @@ describe('cli', function () {
             phantomjs: false,
             args: ['--config.resources./', atTestsRoot, '--config.resources./', atFrameworkPath, '--config.tests.aria-templates.classpaths.includes', 'test.attester.ShouldSucceed', '--config.coverage.files.rootDirectory', atTestsRoot, '--config.coverage.files.includes', '**/*.js', '--launcher-config', path.join(__dirname, 'attester-launcher', 'sauce-labs.yml')].concat(saucelabsBrowsers),
             results: {
-                run: 10,
+                run: 9,
                 failures: 0,
                 errors: 0,
                 skipped: 0

--- a/spec/cli/timeout.spec.js
+++ b/spec/cli/timeout.spec.js
@@ -29,7 +29,7 @@ describe('timeout', function () {
         runs(function () {
             utils.runFromCommandLine({
                 testCase: "timeout after disconnect",
-                timeout: 10000,
+                timeout: 20000,
                 args: ['--max-task-restarts', '0', '--config.tests.mocha.files.includes', 'spec/test-type/mocha/extraScripts/disconnect.js', '--config.tests.mocha.files.includes', 'spec/test-type/mocha/sample-tests/**/*Test.js', '--task-timeout', '500']
             }, function (code, testExecution, errorMessages) {
                 attesterFinished = true;
@@ -56,7 +56,7 @@ describe('timeout', function () {
         });
         waitsFor(function () {
             return attesterFinished && phantomFinished;
-        }, 3000, 'attester and phantom to complete');
+        }, 7000, 'attester and phantom to complete');
         runs(function () {
             expect(attesterFinished).toEqual(true);
             expect(phantomFinished).toEqual(true);

--- a/spec/test-type/mocha/extraScripts/disconnect.js
+++ b/spec/test-type/mocha/extraScripts/disconnect.js
@@ -15,16 +15,10 @@
 
 describe("a test that disconnects the browser", function () {
 	it("should log an error", function (callback) {
-		// This is done asynchronously so that the socket.io manager has time to send
-		// what's already prepared to be sent.
 		setTimeout(function () {
-			// Try to get the socket to close from the top iframe
-			var managers = window.parent.io.managers;
-			for (var host in managers) {
-				// There should be only one
-				managers[host].disconnect();
-			}
-			callback();
+			// Try to get the socket to close from the top iframe by
+			// navigating to a different website
+			window.parent.location = 'about:blank';
 		}, 10);
 	});
 });


### PR DESCRIPTION
Switching to sockjs instead of socket.io makes attester compatible with node.js 8.1.

This PR adds the following non-backward compatible change: the protocol changes, and the new version of attester is not compatible with old versions of attester-launcher and attester-results-ui.

This PR depends on the following other PRs:
- [x] https://github.com/attester/attester-launcher/pull/5
- [x] https://github.com/attester/attester-results-ui/pull/11

Before integrating this PR, those PRs should be integrated and both attester-launcher and attester-results-ui should be released to npm, and their versions should be updated in attester.