### PR TITLE
fix #153 On IE versions older than 9 native methods on the "console" object don't have an "apply" method

### DIFF
--- a/lib/test-server/client/slave-client.js
+++ b/lib/test-server/client/slave-client.js
@@ -251,7 +251,8 @@
     var replaceConsoleFunction = function (console, name, scope) {
         var oldFunction = config.localConsole === false ? emptyFunction : console[name] || emptyFunction;
         console[name] = function () {
-            var res = oldFunction.apply(this, arguments);
+            // IE < 9 compatible: http://stackoverflow.com/questions/5538972/console-log-apply-not-working-in-ie9#comment8444540_5539378
+            var res = Function.prototype.apply.call(oldFunction, this, arguments);
             var taskExecutionId = scope.__taskExecutionId;
             if (!currentTask || currentTask.taskExecutionId !== taskExecutionId) {
                 taskExecutionId = -1;


### PR DESCRIPTION
The workaround is to call the generic "apply" (from "Function"'s prototype) using its own "call" method with proper arguments.