### PR TITLE
Fixing issue when the chosen port is already used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
  - npm install -g npm@3
  - npm --version
  - phantomjs --version
- - npm install -g geckodriver
+ - npm install -g geckodriver@1.4
 before_script:
  - chmod 777 ./travis_sauce_connect.sh
  - ./travis_sauce_connect.sh

--- a/lib/attester/server.js
+++ b/lib/attester/server.js
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-var portfinder = require("portfinder");
 var Q = require('q');
 
 var TestServer = require("../test-server/test-server.js");
@@ -75,28 +74,27 @@ exports.create = function (callback) {
         maxTaskRestarts: config["max-task-restarts"],
         taskRestartOnFailure: config["task-restart-on-failure"]
     }, attester.logger);
+
     testServer.server.on("error", function (error) {
-        testServer.logger.logError("Web server error: %s", [error]);
-        attester.event.emit("server.error");
+        if (error.code === "EADDRINUSE") {
+            // choose an arbitrary unused port:
+            testServer.server.listen(0, config.host);
+        } else {
+            testServer.logger.logError("Web server error: %s", [error]);
+            attester.event.emit("server.error");
+        }
     });
 
-    portfinder.getPort({
-        port: config.port,
-        host: config.host
-    }, function (err, port) {
-        if (err) {
-            attester.event.emit("server.error", "Can't start the server: %s", [err]);
-            return;
-        }
+    testServer.listen(config.port, config.host, function () {
+        var port = testServer.port;
         if (port != config.port && config.port > 0) {
             // logging error instead of a warning so it's more visible in the console
             attester.logger.logError("Port %d unavailable; using %d instead.", [config.port, port]);
         }
-        testServer.listen(port, config.host, function () {
-            testServerReady = true;
-            attester.event.emit("server.listening");
-            callback();
-        });
+
+        testServerReady = true;
+        attester.event.emit("server.listening");
+        callback();
     });
 };
 

--- a/lib/test-server/test-server.js
+++ b/lib/test-server/test-server.js
@@ -273,11 +273,9 @@ TestServer.prototype.getURL = function (urlType) {
 TestServer.prototype.listen = function (port, host, callback) {
     var self = this;
     this.server.listen(port, host, function () {
-        if (!host) {
-            host = self.server.address().address;
-        }
-        self.port = port;
-        self.hostname = host;
+        var address = self.server.address();
+        self.port = address.port;
+        host = self.hostname = address.address;
         var anyIPv4 = (host == "0.0.0.0");
         var anyIPv6 = (host == "::");
         if (anyIPv4 || anyIPv6) {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
         "node-coverage": "1.0.7",
         "noder-js": "1.6.2",
         "optimist": "0.6.1",
-        "portfinder": "1.0.7",
         "q": "1.4.1",
         "semver": "2.3.1",
         "send": "0.14.1",


### PR DESCRIPTION
[portfinder](https://www.npmjs.com/package/portfinder) does not seem to work well, and the way it was used could lead to race conditions if two processes try to use the same port at the same time. The new implementation simply tries to use the configured port and, in case there is an `EADDRINUSE` error, the listen method of the server is called again with port 0, which means an arbitrary unused port will be used, as documented below:
https://nodejs.org/api/net.html#net_server_listen_port_host_backlog_callback