### PR TITLE
Fix auto-exit issues

### DIFF
--- a/lib/test-server/client/slave-client.js
+++ b/lib/test-server/client/slave-client.js
@@ -98,7 +98,7 @@
 
     var removeIframe = function () {
         if (iframe) {
-            window.attester = null;
+            window.attester = new AttesterAPI();
             iframeParent.removeChild(iframe);
             iframe = null;
         }


### PR DESCRIPTION
Avoid setting attester variable to null to fix issue when phantomjs instance is waiting for a new test to execute and polling for errors is executed.