### PR TITLE
Avoiding the same id to be given to different campaigns

### DIFF
--- a/lib/test-campaign/test-campaign.js
+++ b/lib/test-campaign/test-campaign.js
@@ -34,9 +34,10 @@ var pad2 = function (number) {
     }
 };
 
+var counter = 0;
 var createCampaignId = function (date) {
-    // TODO when we want to reliably support multiple campaigns, we should verify there's no campaign with the exact same ID
-    return [date.getFullYear(), pad2(date.getMonth() + 1), pad2(date.getDate()), pad2(date.getHours()), pad2(date.getMinutes()), pad2(date.getSeconds()), pad2(Math.floor(Math.random() * 100))].join('');
+    counter++;
+    return [date.getFullYear(), pad2(date.getMonth() + 1), pad2(date.getDate()), pad2(date.getHours()), pad2(date.getMinutes()), pad2(date.getSeconds()), pad2(Math.floor(Math.random() * 100)), pad2(counter)].join('');
 };
 
 var TestCampaign = function (config, parentLogger) {


### PR DESCRIPTION
This commit adds a counter so that different campaigns have different ids even if they are created at the same second and have the same random part.