### PR TITLE
fix uncaught exception when there is no error message

### DIFF
--- a/lib/reports/json-report.js
+++ b/lib/reports/json-report.js
@@ -246,7 +246,7 @@ var queuedEventTypes = {
         this.tasksErrors[browserName].push({
             taskName: taskAndBrowserName[0],
             method: event.method || "",
-            errorMessage: err.message
+            errorMessage: err.message || ""
         });
 
         if (err.failure) {


### PR DESCRIPTION
This commit improves consistency between `json-report.js` and `console-report.js` so that `json-report.js` does as `console-report.js` and no longer throws an uncaught exception when the error message is undefined
(using `err.message || ""`).