### PR TITLE
fix issue with error message with mocha connector

### DIFF
--- a/lib/test-type/mocha/client/connector.js
+++ b/lib/test-type/mocha/client/connector.js
@@ -128,7 +128,10 @@
         runner.on("fail", function (test, err) {
             attester.testError({
                 name: testName + " " + test.title,
-                error: err
+                error: {
+                    message: err.message,
+                    stack: attester.stackTrace(err)
+                }
             });
         });
 


### PR DESCRIPTION
Error messages do not seem to be correctly sent on PhantomJS 2.x when using the mocha connector. This commit fixes this issue.