### PR TITLE
Adding --public-host and --public-port options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,11 @@ the memory consumption of attester.
 
 `--host <host>` Host used for the internal web server.
 
-`--port <number>` Port used for the internal web server. If set to `0` (default), an available port is automatically selected.
+`--port <number>` Port used for the internal web server. If set to `0`, an available port is automatically selected.
+
+`--public-host <host>` Public host of the internal web server, which, when defined, is used instead of --host to create the URL to be called from browsers.
+
+`--public-port <number>` Public port of the internal web server, which, when defined, is used instead of --port to create the URL to be called from browsers.
 
 `--server-only` Only starts the web server, and configure it for the test campaign but do not start the campaign. This is useful to
 run tests manually.

--- a/bin/attester.js
+++ b/bin/attester.js
@@ -36,6 +36,8 @@ var opt = optimist.usage('Usage: $0 [options] [config.yml|config.json]').boolean
     'phantomjs-path': 'Path to PhantomJS executable.',
     'port': 'Port used for the web server. If set to 0, an available port is automatically selected.',
     'host': 'Host used for the web server.',
+    'public-port': 'Public host of the web server, which, when defined, is used instead of --host to create the URL to be called from browsers.',
+    'public-host': 'Public port of the web server, which, when defined, is used instead of --port to create the URL to be called from browsers.',
     'predictable-urls': 'If true, resources served by the campaign have predictable URLs (campaign1, campaign2...). Otherwise, the campaign part in the URL is campaign ID. Useful for debugging.',
     'run-browser': 'Path to any browser executable to execute the tests. Can be repeated multiple times.',
     'server-only': 'Only starts the web server, and configure it for the test campaign but do not start the campaign.',

--- a/lib/attester/server.js
+++ b/lib/attester/server.js
@@ -72,7 +72,9 @@ exports.create = function (callback) {
         flashPolicyServer: config["flash-policy-server"],
         taskTimeout: config["task-timeout"],
         maxTaskRestarts: config["max-task-restarts"],
-        taskRestartOnFailure: config["task-restart-on-failure"]
+        taskRestartOnFailure: config["task-restart-on-failure"],
+        publicHost: config['public-host'],
+        publicPort: config['public-port']
     }, attester.logger);
 
     testServer.server.on("error", function (error) {

--- a/lib/test-server/test-server.js
+++ b/lib/test-server/test-server.js
@@ -289,8 +289,8 @@ TestServer.prototype.getURL = function (urlType) {
     }
     return url.format({
         protocol: 'http',
-        port: this.port,
-        hostname: this.hostname,
+        port: this.config.publicPort || this.port,
+        hostname: this.config.publicHost || this.hostname,
         pathname: pathname
     });
 };


### PR DESCRIPTION
Those options are useful if, for example, attester runs inside a docker container with the attester port exposed on the host machine and if it has to be reached, from browsers launched with the `--launcher-config` option, with a different host and port than the ones used to open the server socket in the container.