### PR TITLE
Allowing browser names containing a space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
         run: npm test
         if: steps.test2.outcome == 'failure'
       - run: killall sc && sleep 5; cat $HOME/sauce-connect.log
-        if: always()
+        if: always() && (env.SAUCE_ACCESS_KEY != '')

--- a/lib/test-campaign/browser.js
+++ b/lib/test-campaign/browser.js
@@ -19,10 +19,10 @@ var browserMatch = require('../util/browser-detection.js').browserMatch;
  * @see Browser.prototype.parseBrowserConfig
  * <li> Usage: </li>
  * <li> Input: 'Chrome >=30 on Desktop Windows with flags as Chrome Canary 30' </li>
- * <li> Match: [1] = 'Chrome', [2] = '>=30', [3] = 'Desktop Windows', [4] = 'Chrome Canary 30' </li>
- * Parts 2, 3, 4 are optional, will be undefined if not found.
+ * <li> Match: [1] = 'Chrome', [2] = '>=30', [3] = 'Desktop Windows', [4] = 'flags', [5] = 'Chrome Canary 30' </li>
+ * Parts 2, 3, 4, 5 are optional, will be undefined if not found.
  */
-var _browserCfgRegex = /^\s*(\S+)(?:\s+(\W*\d\S*))?(?:\s+on\s+(.*?))?(?:\s+with\s+(.*?))?(?:\s+as\s+(.*?))?\s*$/i;
+var _browserCfgRegex = /^\s*(\S.*?)(?:\s+(\W*\d\S*))?(?:\s+on\s+(.*?))?(?:\s+with\s+(.*?))?(?:\s+as\s+(.*?))?\s*$/i;
 
 var buildNameFromConfig = function (config) {
     if (config.displayAs) {

--- a/spec/config/parseBrowserConfig.spec.js
+++ b/spec/config/parseBrowserConfig.spec.js
@@ -29,10 +29,30 @@ describe("parse browser config", function () {
             });
         });
 
+        it("should read plain browser name with space", function () {
+            expect(Browser.parseBrowserConfig("Chrome Headless")).toEqual({
+                browserName: "Chrome Headless",
+                browserVersion: undefined,
+                os: undefined,
+                displayAs: undefined,
+                flags: undefined
+            });
+        });
+
         it("should read name with version", function () {
             expect(Browser.parseBrowserConfig("IE 10")).toEqual({
                 browserName: "IE",
                 browserVersion: "10",
+                os: undefined,
+                displayAs: undefined,
+                flags: undefined
+            });
+        });
+
+        it("should read name with space with version", function () {
+            expect(Browser.parseBrowserConfig("Chrome Headless 83")).toEqual({
+                browserName: "Chrome Headless",
+                browserVersion: "83",
                 os: undefined,
                 displayAs: undefined,
                 flags: undefined
@@ -49,9 +69,29 @@ describe("parse browser config", function () {
             });
         });
 
+        it("should read name with space with semver", function () {
+            expect(Browser.parseBrowserConfig("Chrome Headless >=83")).toEqual({
+                browserName: "Chrome Headless",
+                browserVersion: ">=83",
+                os: undefined,
+                displayAs: undefined,
+                flags: undefined
+            });
+        });
+
         it("should read name with os", function () {
             expect(Browser.parseBrowserConfig("Chrome on Windows 7")).toEqual({
                 browserName: "Chrome",
+                browserVersion: undefined,
+                os: "Windows 7",
+                displayAs: undefined,
+                flags: undefined
+            });
+        });
+
+        it("should read name with space with os", function () {
+            expect(Browser.parseBrowserConfig("Chrome Headless on Windows 7")).toEqual({
+                browserName: "Chrome Headless",
                 browserVersion: undefined,
                 os: "Windows 7",
                 displayAs: undefined,
@@ -69,6 +109,16 @@ describe("parse browser config", function () {
             });
         });
 
+        it("should read name with space with semver and os", function () {
+            expect(Browser.parseBrowserConfig("Chrome Headless 30 on Windows 7")).toEqual({
+                browserName: "Chrome Headless",
+                browserVersion: "30",
+                os: "Windows 7",
+                displayAs: undefined,
+                flags: undefined
+            });
+        });
+
         it("should read name with semver and alias", function () {
             expect(Browser.parseBrowserConfig("Firefox ~25 as Firefox Nightly")).toEqual({
                 browserName: "Firefox",
@@ -79,9 +129,29 @@ describe("parse browser config", function () {
             });
         });
 
+        it("should read name with space with semver and alias", function () {
+            expect(Browser.parseBrowserConfig("Chrome Headless ~83 as Latest Chrome")).toEqual({
+                browserName: "Chrome Headless",
+                browserVersion: "~83",
+                os: undefined,
+                displayAs: "Latest Chrome",
+                flags: undefined
+            });
+        });
+
         it("should read name with version, os, and alias", function () {
             expect(Browser.parseBrowserConfig("Chrome 30 on Desktop Linux as Chrome Canary Linux")).toEqual({
                 browserName: "Chrome",
+                browserVersion: "30",
+                os: "Desktop Linux",
+                displayAs: "Chrome Canary Linux",
+                flags: undefined
+            });
+        });
+
+        it("should read name with space with version, os, and alias", function () {
+            expect(Browser.parseBrowserConfig("Chrome Headless 30 on Desktop Linux as Chrome Canary Linux")).toEqual({
+                browserName: "Chrome Headless",
                 browserVersion: "30",
                 os: "Desktop Linux",
                 displayAs: "Chrome Canary Linux",
@@ -99,12 +169,32 @@ describe("parse browser config", function () {
             });
         });
 
+        it("should read name with space with version and flags", function () {
+            expect(Browser.parseBrowserConfig("Chrome Headless 83 with JAWS")).toEqual({
+                browserName: "Chrome Headless",
+                browserVersion: "83",
+                flags: "JAWS",
+                os: undefined,
+                displayAs: undefined
+            });
+        });
+
         it("should read name with version, flags and alias", function () {
             expect(Browser.parseBrowserConfig("IE 11 with JAWS as IEJAWS")).toEqual({
                 browserName: "IE",
                 browserVersion: "11",
                 flags: "JAWS",
                 displayAs: "IEJAWS",
+                os: undefined
+            });
+        });
+
+        it("should read name with space with version, flags and alias", function () {
+            expect(Browser.parseBrowserConfig("Chrome Headless 83 with JAWS as CHROMEJAWS")).toEqual({
+                browserName: "Chrome Headless",
+                browserVersion: "83",
+                flags: "JAWS",
+                displayAs: "CHROMEJAWS",
                 os: undefined
             });
         });
@@ -119,10 +209,30 @@ describe("parse browser config", function () {
             });
         });
 
+        it("should read name with space with flags and alias", function () {
+            expect(Browser.parseBrowserConfig("Chrome Headless with JAWS as CHROMEJAWS")).toEqual({
+                browserName: "Chrome Headless",
+                flags: "JAWS",
+                displayAs: "CHROMEJAWS",
+                os: undefined,
+                browserVersion: undefined
+            });
+        });
+
         it("should read name with version, os, flags and alias", function () {
             expect(Browser.parseBrowserConfig("Chrome 30 on Desktop Linux with robot as Chrome Canary Linux")).toEqual({
                 browserName: "Chrome",
                 browserVersion: "30",
+                os: "Desktop Linux",
+                flags: "robot",
+                displayAs: "Chrome Canary Linux"
+            });
+        });
+
+        it("should read name with space with version, os, flags and alias", function () {
+            expect(Browser.parseBrowserConfig("Chrome Headless 84 on Desktop Linux with robot as Chrome Canary Linux")).toEqual({
+                browserName: "Chrome Headless",
+                browserVersion: "84",
                 os: "Desktop Linux",
                 flags: "robot",
                 displayAs: "Chrome Canary Linux"
@@ -134,6 +244,13 @@ describe("parse browser config", function () {
         it("should not care about whitespace", function () {
             expect(Browser.parseBrowserConfig("   Chrome    30   on   Desktop Linux    as    Chrome Canary 30   ")).toEqual({
                 browserName: "Chrome",
+                browserVersion: "30",
+                os: "Desktop Linux",
+                displayAs: "Chrome Canary 30",
+                flags: undefined
+            });
+            expect(Browser.parseBrowserConfig("   Chrome Headless    30   on   Desktop Linux    as    Chrome Canary 30   ")).toEqual({
+                browserName: "Chrome Headless",
                 browserVersion: "30",
                 os: "Desktop Linux",
                 displayAs: "Chrome Canary 30",
@@ -159,12 +276,6 @@ describe("parse browser config", function () {
 
         it("should return empty object (unrestricted browser) for null input string", function () {
             expect(Browser.parseBrowserConfig(null)).toEqual({});
-        });
-
-        it("should return 'unparsable browser' for no match", function () {
-            expect(Browser.parseBrowserConfig("I have no idea what I'm passing")).toEqual({
-                browserName: "unparsable browser"
-            });
         });
     });
 


### PR DESCRIPTION
ua-parser-js can return browser names containing a space (such as "Chrome Headless").